### PR TITLE
Fix NotSupportedException when condition required was not supplied

### DIFF
--- a/src/Rules.Framework/Evaluation/ValueEvaluation/Dispatchers/ConditionEvalDispatchProvider.cs
+++ b/src/Rules.Framework/Evaluation/ValueEvaluation/Dispatchers/ConditionEvalDispatchProvider.cs
@@ -47,12 +47,19 @@ namespace Rules.Framework.Evaluation.ValueEvaluation.Dispatchers
                 IEnumerable _ when !(leftOperand is string) => ManyToOne,
                 object _ when rightOperand is IEnumerable && !(rightOperand is string) => OneToMany,
                 object _ => OneToOne,
+                null when OperatorSupportsOneMultiplicityLeftOperand(@operator) && rightOperand is IEnumerable && !(rightOperand is string) => OneToMany,
+                null when OperatorSupportsOneMultiplicityLeftOperand(@operator) => OneToOne,
                 _ => throw new NotSupportedException()
             };
 
             this.ThrowIfUnsupportedOperandsAndOperatorCombination($"{combination}-{@operator}");
 
             return this.dispatchers[combination];
+        }
+
+        private bool OperatorSupportsOneMultiplicityLeftOperand(Operators @operator)
+        {
+            return this.supportedCombinations.Where(x => x.Contains(@operator.ToString())).Any(x => x.Contains("one-to"));
         }
 
         private void ThrowIfUnsupportedOperandsAndOperatorCombination(string combination)

--- a/tests/Rules.Framework.IntegrationTests.Common/Scenarios/Scenario4/DiscountConditions.cs
+++ b/tests/Rules.Framework.IntegrationTests.Common/Scenarios/Scenario4/DiscountConditions.cs
@@ -5,5 +5,6 @@ namespace Rules.Framework.IntegrationTests.Common.Scenarios.Scenario4
         ProductBrand = 1,
         ProductRecommendedRetailPrice = 2,
         ProductTier = 3,
+        ProductColor = 4
     }
 }

--- a/tests/Rules.Framework.IntegrationTests/Tests/Scenario4/DiscountCampaignTests.cs
+++ b/tests/Rules.Framework.IntegrationTests/Tests/Scenario4/DiscountCampaignTests.cs
@@ -1,6 +1,7 @@
 namespace Rules.Framework.IntegrationTests.Tests.Scenario4
 {
     using System;
+    using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
     using FluentAssertions;
@@ -11,6 +12,13 @@ namespace Rules.Framework.IntegrationTests.Tests.Scenario4
 
     public class DiscountCampaignTests
     {
+        public enum ProductColor
+        {
+            Blue = 0,
+            Red = 1,
+            White = 2
+        }
+
         [Fact]
         public async Task DiscountsWeekend_Adding15PercentRulePerBrandAndEvaluatingOneOfTheBrands_Returns15PercentDiscountRate()
         {
@@ -162,6 +170,180 @@ namespace Rules.Framework.IntegrationTests.Tests.Scenario4
             // Assert 3
             actual.Should().NotBeNull();
             actual.Should().BeEquivalentTo(rule);
+        }
+
+        [Fact]
+        public async Task DiscountsWeekend_AddingRuleWithNullTestConditionAndInputWithoutConditions_ReturnNull()
+        {
+            // Arrange
+            IRulesDataSource<DiscountConfigurations, DiscountConditions> rulesDataSource
+                = new InMemoryRulesDataSource<DiscountConfigurations, DiscountConditions>(Enumerable.Empty<Rule<DiscountConfigurations, DiscountConditions>>());
+
+            RulesEngine<DiscountConfigurations, DiscountConditions> rulesEngine = RulesEngineBuilder.CreateRulesEngine()
+                .WithContentType<DiscountConfigurations>()
+                .WithConditionType<DiscountConditions>()
+                .SetDataSource(rulesDataSource)
+                .Build();
+
+            // Act 1 - Create rule with "equal" operator
+            RuleBuilderResult<DiscountConfigurations, DiscountConditions> ruleBuilderResult =
+                RuleBuilder
+                    .NewRule<DiscountConfigurations, DiscountConditions>()
+                    .WithName("Blue Product")
+                    .WithContentContainer(new ContentContainer<DiscountConfigurations>(DiscountConfigurations.DiscountCampaigns, t => ProductColor.Blue.ToString()))
+                    .WithDateBegin(DateTime.Parse("2021-05-29Z"))
+                    .WithCondition(x1 =>
+                                x1.AsValued(DiscountConditions.ProductColor)
+                                    .OfDataType<string>()
+                                    .WithComparisonOperator(Operators.Equal)
+                                    .SetOperand(ProductColor.Blue.ToString())
+                                    .Build()
+                    ).Build();
+
+            // Assert 1
+            ruleBuilderResult.Should().NotBeNull();
+            string errors = ruleBuilderResult.Errors.Any() ? ruleBuilderResult.Errors.Aggregate((s1, s2) => $"{s1}\n- {s2}") : string.Empty;
+            ruleBuilderResult.IsSuccess.Should().BeTrue(
+                $"errors have occurred while creating rule: \n[\n- {errors}\n]");
+
+            // Act 2 - Add new rule with "in" operator
+            Rule<DiscountConfigurations, DiscountConditions> rule = ruleBuilderResult.Rule;
+
+            RuleOperationResult addRuleResult = await rulesEngine.AddRuleAsync(rule, RuleAddPriorityOption.AtTop).ConfigureAwait(false);
+
+            // Assert 2 - Verify if rule was added
+            addRuleResult.Should().NotBeNull();
+            addRuleResult.IsSuccess.Should().BeTrue();
+
+            // Act 3 - Evaluate new rule with "in" operator
+            DateTime matchDateTime = DateTime.Parse("2021-05-29T12:34:52Z");
+            var conditions = new List<Condition<DiscountConditions>>();
+
+            Rule<DiscountConfigurations, DiscountConditions> actual = await rulesEngine.MatchOneAsync(DiscountConfigurations.DiscountCampaigns, matchDateTime, conditions).ConfigureAwait(false);
+
+            // Assert 3
+            actual.Should().BeNull();
+        }
+
+        [Fact]
+        public async Task DiscountsWeekend_AddingRuleWithNullTestConditionAndInputWithMatchingConditions_ReturnNotNull()
+        {
+            // Arrange
+            IRulesDataSource<DiscountConfigurations, DiscountConditions> rulesDataSource
+                = new InMemoryRulesDataSource<DiscountConfigurations, DiscountConditions>(Enumerable.Empty<Rule<DiscountConfigurations, DiscountConditions>>());
+
+            RulesEngine<DiscountConfigurations, DiscountConditions> rulesEngine = RulesEngineBuilder.CreateRulesEngine()
+                .WithContentType<DiscountConfigurations>()
+                .WithConditionType<DiscountConditions>()
+                .SetDataSource(rulesDataSource)
+                .Build();
+
+            // Act 1 - Create rule with "equal" operator
+            RuleBuilderResult<DiscountConfigurations, DiscountConditions> ruleBuilderResult =
+                RuleBuilder
+                    .NewRule<DiscountConfigurations, DiscountConditions>()
+                    .WithName("Blue Product")
+                    .WithContentContainer(new ContentContainer<DiscountConfigurations>(DiscountConfigurations.DiscountCampaigns, t => ProductColor.Blue.ToString()))
+                    .WithDateBegin(DateTime.Parse("2021-05-29Z"))
+                    .WithCondition(x1 =>
+                                x1.AsValued(DiscountConditions.ProductColor)
+                                    .OfDataType<string>()
+                                    .WithComparisonOperator(Operators.Equal)
+                                    .SetOperand(ProductColor.Blue.ToString())
+                                    .Build()
+                    ).Build();
+
+            // Assert 1
+            ruleBuilderResult.Should().NotBeNull();
+            string errors = ruleBuilderResult.Errors.Any() ? ruleBuilderResult.Errors.Aggregate((s1, s2) => $"{s1}\n- {s2}") : string.Empty;
+            ruleBuilderResult.IsSuccess.Should().BeTrue(
+                $"errors have occurred while creating rule: \n[\n- {errors}\n]");
+
+            // Act 2 - Add new rule with "in" operator
+            Rule<DiscountConfigurations, DiscountConditions> rule = ruleBuilderResult.Rule;
+
+            RuleOperationResult addRuleResult = await rulesEngine.AddRuleAsync(rule, RuleAddPriorityOption.AtTop).ConfigureAwait(false);
+
+            // Assert 2 - Verify if rule was added
+            addRuleResult.Should().NotBeNull();
+            addRuleResult.IsSuccess.Should().BeTrue();
+
+            // Act 3 - Evaluate new rule with "in" operator
+            DateTime matchDateTime = DateTime.Parse("2021-05-29T12:34:52Z");
+            Condition<DiscountConditions>[] conditions = new[]
+            {
+                new Condition<DiscountConditions>
+                {
+                    Type = DiscountConditions.ProductColor,
+                    Value = ProductColor.Blue.ToString()
+                }
+            };
+
+            Rule<DiscountConfigurations, DiscountConditions> actual = await rulesEngine.MatchOneAsync(DiscountConfigurations.DiscountCampaigns, matchDateTime, conditions).ConfigureAwait(false);
+
+            // Assert 3
+            actual.Should().NotBeNull();
+            actual.Should().BeEquivalentTo(rule);
+        }
+
+        [Fact]
+        public async Task DiscountsWeekend_AddingRuleWithNullTestConditionAndInputWithoutMatchingConditions_ReturnNull()
+        {
+            // Arrange
+            IRulesDataSource<DiscountConfigurations, DiscountConditions> rulesDataSource
+                = new InMemoryRulesDataSource<DiscountConfigurations, DiscountConditions>(Enumerable.Empty<Rule<DiscountConfigurations, DiscountConditions>>());
+
+            RulesEngine<DiscountConfigurations, DiscountConditions> rulesEngine = RulesEngineBuilder.CreateRulesEngine()
+                .WithContentType<DiscountConfigurations>()
+                .WithConditionType<DiscountConditions>()
+                .SetDataSource(rulesDataSource)
+                .Build();
+
+            // Act 1 - Create rule with "equal" operator
+            RuleBuilderResult<DiscountConfigurations, DiscountConditions> ruleBuilderResult =
+                RuleBuilder
+                    .NewRule<DiscountConfigurations, DiscountConditions>()
+                    .WithName("Blue Product")
+                    .WithContentContainer(new ContentContainer<DiscountConfigurations>(DiscountConfigurations.DiscountCampaigns, t => ProductColor.Blue.ToString()))
+                    .WithDateBegin(DateTime.Parse("2021-05-29Z"))
+                    .WithCondition(x1 =>
+                                x1.AsValued(DiscountConditions.ProductColor)
+                                    .OfDataType<string>()
+                                    .WithComparisonOperator(Operators.Equal)
+                                    .SetOperand(ProductColor.Blue.ToString())
+                                    .Build()
+                    ).Build();
+
+            // Assert 1
+            ruleBuilderResult.Should().NotBeNull();
+            string errors = ruleBuilderResult.Errors.Any() ? ruleBuilderResult.Errors.Aggregate((s1, s2) => $"{s1}\n- {s2}") : string.Empty;
+            ruleBuilderResult.IsSuccess.Should().BeTrue(
+                $"errors have occurred while creating rule: \n[\n- {errors}\n]");
+
+            // Act 2 - Add new rule with "in" operator
+            Rule<DiscountConfigurations, DiscountConditions> rule = ruleBuilderResult.Rule;
+
+            RuleOperationResult addRuleResult = await rulesEngine.AddRuleAsync(rule, RuleAddPriorityOption.AtTop).ConfigureAwait(false);
+
+            // Assert 2 - Verify if rule was added
+            addRuleResult.Should().NotBeNull();
+            addRuleResult.IsSuccess.Should().BeTrue();
+
+            // Act 3 - Evaluate new rule with "in" operator
+            DateTime matchDateTime = DateTime.Parse("2021-05-29T12:34:52Z");
+            Condition<DiscountConditions>[] conditions = new[]
+            {
+                new Condition<DiscountConditions>
+                {
+                    Type = DiscountConditions.ProductColor,
+                    Value = ProductColor.White.ToString()
+                }
+            };
+
+            Rule<DiscountConfigurations, DiscountConditions> actual = await rulesEngine.MatchOneAsync(DiscountConfigurations.DiscountCampaigns, matchDateTime, conditions).ConfigureAwait(false);
+
+            // Assert 3
+            actual.Should().BeNull();
         }
     }
 }


### PR DESCRIPTION
## Description

What was done:

- When a condition is required to match a rule and was not supplied, in order to avoid NotSupportedException when evaluating each type of ConditionEvalDispatcher to select, we decide to consider OneToMany in case the right operand would be a list and OneToOne if its a single element.

Closes #41.

## Change checklist

- [x] Code follows the [code rules guidelines](../CONTRIBUTING.md#code-rules) of this project
- [x] Commit messages follow the [commit rules](../CONTRIBUTING.md#commit-rules) of this project
- [x] I have self-reviewed my changes before submitting this pull request
- [ ] I have covered new/changed code with new tests and/or adjusted existent ones
- [ ] I have made changes necessary to update the documentation accordingly

Please also check the [_I want to contribute_](../CONTRIBUTING.md#i-want-to-contribute) guidelines and make sure you have done accordingly.

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)