### PR TITLE
Fix wrong null date interval evaluation

### DIFF
--- a/src/Rules.Framework.Providers.InMemory/InMemoryProviderRulesDataSource.cs
+++ b/src/Rules.Framework.Providers.InMemory/InMemoryProviderRulesDataSource.cs
@@ -12,7 +12,7 @@ namespace Rules.Framework.Providers.InMemory
     /// </summary>
     /// <typeparam name="TContentType">The type of the content type.</typeparam>
     /// <typeparam name="TConditionType">The type of the condition type.</typeparam>
-    /// <seealso cref="Rules.Framework.IRulesDataSource{TContentType, TConditionType}" />
+    /// <seealso cref="Rules.Framework.IRulesDataSource{TContentType, TConditionType}"/>
     public class InMemoryProviderRulesDataSource<TContentType, TConditionType> : IRulesDataSource<TContentType, TConditionType>
     {
         private readonly IInMemoryRulesStorage<TContentType, TConditionType> inMemoryRulesStorage;
@@ -48,7 +48,8 @@ namespace Rules.Framework.Providers.InMemory
         }
 
         /// <summary>
-        /// Gets the rules categorized with specified <paramref name="contentType" /> between <paramref name="dateBegin" /> and <paramref name="dateEnd" />.
+        /// Gets the rules categorized with specified <paramref name="contentType"/> between
+        /// <paramref name="dateBegin"/> and <paramref name="dateEnd"/>.
         /// </summary>
         /// <param name="contentType">the content type categorization.</param>
         /// <param name="dateBegin">the filtering begin date.</param>
@@ -62,7 +63,7 @@ namespace Rules.Framework.Providers.InMemory
 
                 IEnumerable<RuleDataModel<TContentType, TConditionType>> filteredByDate = ruleDataModels.Where(r =>
                     (r.DateBegin >= dateBegin && r.DateBegin < dateEnd)
-                    || (r.DateEnd is null && r.DateEnd >= dateBegin && r.DateEnd < dateEnd)
+                    || (!(r.DateEnd is null) && r.DateEnd >= dateBegin && r.DateEnd < dateEnd)
                     || (r.DateBegin < dateBegin && (r.DateEnd is null || r.DateEnd > dateEnd)));
 
                 return filteredByDate.Select(r => this.ruleFactory.CreateRule(r)).ToList().AsEnumerable();

--- a/tests/Rules.Framework.IntegrationTests.Common/Scenarios/Scenario2/CarInsuranceAdvices.cs
+++ b/tests/Rules.Framework.IntegrationTests.Common/Scenarios/Scenario2/CarInsuranceAdvices.cs
@@ -8,6 +8,8 @@ namespace Rules.Framework.IntegrationTests.Common.Scenarios.Scenario2
 
         PayNewCar = 3,
 
-        PerformInvestigation = 4
+        PerformInvestigation = 4,
+
+        PayOldCar = 5
     }
 }

--- a/tests/Rules.Framework.IntegrationTests.Common/Scenarios/Scenario2/rules-framework-tests.car-insurance-advisor.json
+++ b/tests/Rules.Framework.IntegrationTests.Common/Scenarios/Scenario2/rules-framework-tests.car-insurance-advisor.json
@@ -5,7 +5,7 @@
     "DateBegin": "2018-01-01",
     "DateEnd": null,
     "Name": "Car Insurance Advise on repair costs lower than franchise boundary",
-    "Priority": 3,
+    "Priority": 4,
     "RootCondition": {
       "LogicalOperator": "And",
       "ChildConditionNodes": [
@@ -22,6 +22,33 @@
           "LogicalOperator": "Eval",
           "Operator": "LesserThan",
           "Operand": "80"
+        }
+      ]
+    }
+  },
+  {
+    "Content": "PayOldCar",
+    "ContentTypeCode": 1,
+    "DateBegin": "2010-01-01",
+    "DateEnd": "2016-06-01 23:59:59.999",
+    "Name": "Car Insurance Advise on repair costs equal to 0",
+    "Priority": 3,
+    "RootCondition": {
+      "LogicalOperator": "And",
+      "ChildConditionNodes": [
+        {
+          "ConditionType": "RepairCosts",
+          "DataType": "Decimal",
+          "LogicalOperator": "Eval",
+          "Operator": "Equal",
+          "Operand": "0.0"
+        },
+        {
+          "ConditionType": "RepairCostsCommercialValueRate",
+          "DataType": "Decimal",
+          "LogicalOperator": "Eval",
+          "Operator": "Equal",
+          "Operand": "0.0"
         }
       ]
     }


### PR DESCRIPTION
## Description

What was done:

- When the dates are being evaluated when checking for null we want to ensure the DateEnd is not null instead of null.

Closes #40

## Change checklist

- [x] Code follows the [code rules guidelines](../CONTRIBUTING.md#code-rules) of this project
- [x] Commit messages follow the [commit rules](../CONTRIBUTING.md#commit-rules) of this project
- [x] I have self-reviewed my changes before submitting this pull request
- [x] I have covered new/changed code with new tests and/or adjusted existent ones
- [ ] I have made changes necessary to update the documentation accordingly

Please also check the [_I want to contribute_](../CONTRIBUTING.md#i-want-to-contribute) guidelines and make sure you have done accordingly.

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)