### PR TITLE
Add StartsWith and EndsWith Operator

### DIFF
--- a/docs/add-rules.md
+++ b/docs/add-rules.md
@@ -97,6 +97,8 @@ Next step is to define a comparison operator using method `WithComparisonOperato
 - LesserThanOrEqual (`<=`)
 - Contains
 - In
+- StartsWith
+- EndsWith
 
 Not all comparison operators are supported for all data types, some combinations of them are not valid. This will be validated by rule builder and a validation error will be returned if a invalid combination is attempted. Check the following grid to see combinations are valid or not:
 
@@ -110,6 +112,8 @@ Not all comparison operators are supported for all data types, some combinations
 |LesserThanOrEqual (`<=`)|:heavy_check_mark:|:heavy_check_mark:|:x:|:x:|
 |Contains|:x:|:x:|:x:|:heavy_check_mark:|
 |In|:heavy_check_mark:|:heavy_check_mark:|:x:|:heavy_check_mark:|
+|StartsWith|:x:|:x:|:x:|:heavy_check_mark:|
+|EndsWith|:x:|:x:|:x:|:heavy_check_mark:|
 
 You should also take into consideration the multiplicity of operands when setting value conditions on a rule. Theoretically, all multiplicity combinations are supported (one to one, one to many, many to one, many to many), but that also relies on a per-operator implementation for each multiplicity. Please refer to following combinations to see which multiplicities are supported or not:
 
@@ -123,6 +127,8 @@ You should also take into consideration the multiplicity of operands when settin
 |LesserThanOrEqual (`<=`)|:heavy_check_mark:|:x:|:x:|:x:|
 |Contains|:heavy_check_mark:|:x:|:x:|:x:|
 |In|:x:|:heavy_check_mark:|:x:|:x:|
+|StartsWith|:heavy_check_mark:|:x:|:x:|:x:|
+|EndsWith|:heavy_check_mark:|:x:|:x:|:x:|
 
 At last, you should complete valued condition node build with a right hand operand with following methods, according to wanted multiplicity:
 

--- a/src/Rules.Framework/Builder/Validation/ValueConditionNodeValidator.cs
+++ b/src/Rules.Framework/Builder/Validation/ValueConditionNodeValidator.cs
@@ -1,9 +1,9 @@
 namespace Rules.Framework.Builder.Validation
 {
-    using System.Collections.Generic;
     using FluentValidation;
     using Rules.Framework.Core;
     using Rules.Framework.Core.ConditionNodes;
+    using System.Collections.Generic;
 
     internal class ValueConditionNodeValidator<TConditionType> : AbstractValidator<ValueConditionNode<TConditionType>>
     {
@@ -19,7 +19,7 @@ namespace Rules.Framework.Builder.Validation
             this.RuleFor(c => c.Operator).IsInEnum();
 
             this.RuleFor(c => c.Operator)
-                .IsContainedOn(Operators.Equal, Operators.NotEqual, Operators.Contains, Operators.In)
+                .IsContainedOn(Operators.Equal, Operators.NotEqual, Operators.Contains, Operators.In, Operators.StartsWith, Operators.EndsWith)
                 .When(c => c.DataType == DataTypes.String)
                 .WithMessage(cn => $"Condition nodes with data type '{cn.DataType}' can't define a operator of type '{cn.Operator}'.");
 

--- a/src/Rules.Framework/Core/Operators.cs
+++ b/src/Rules.Framework/Core/Operators.cs
@@ -45,6 +45,16 @@ namespace Rules.Framework.Core
         /// <summary>
         /// The in operator.
         /// </summary>
-        In = 9
+        In = 9,
+
+        /// <summary>
+        /// The starts with operator.
+        /// </summary>
+        StartsWith = 10,
+
+        /// <summary>
+        /// The ends with operator.
+        /// </summary>
+        EndsWith = 11
     }
 }

--- a/src/Rules.Framework/Evaluation/ValueEvaluation/Dispatchers/ConditionEvalDispatchProvider.cs
+++ b/src/Rules.Framework/Evaluation/ValueEvaluation/Dispatchers/ConditionEvalDispatchProvider.cs
@@ -1,10 +1,10 @@
 namespace Rules.Framework.Evaluation.ValueEvaluation.Dispatchers
 {
+    using Rules.Framework.Core;
     using System;
     using System.Collections;
     using System.Collections.Generic;
     using System.Linq;
-    using Rules.Framework.Core;
 
     internal class ConditionEvalDispatchProvider : IConditionEvalDispatchProvider
     {
@@ -36,6 +36,8 @@ namespace Rules.Framework.Evaluation.ValueEvaluation.Dispatchers
                 $"{OneToOne}-{Operators.LesserThanOrEqual}",
                 $"{OneToOne}-{Operators.Contains}",
                 $"{OneToMany}-{Operators.In}",
+                $"{OneToOne}-{Operators.StartsWith}",
+                $"{OneToOne}-{Operators.EndsWith}",
             };
         }
 

--- a/src/Rules.Framework/Evaluation/ValueEvaluation/EndsWithOperatorEvalStrategy.cs
+++ b/src/Rules.Framework/Evaluation/ValueEvaluation/EndsWithOperatorEvalStrategy.cs
@@ -6,7 +6,7 @@ namespace Rules.Framework.Evaluation.ValueEvaluation
     {
         public bool Eval(object leftOperand, object rightOperand)
         {
-            if (leftOperand is string)
+            if (leftOperand is string && rightOperand is string)
             {
                 string leftOperandAsString = leftOperand as string;
                 string rightOperandAsString = rightOperand as string;
@@ -14,7 +14,7 @@ namespace Rules.Framework.Evaluation.ValueEvaluation
                 return leftOperandAsString.EndsWith(rightOperandAsString);
             }
 
-            throw new NotSupportedException($"Unsupported 'startswith' comparison between operands of type '{leftOperand?.GetType().FullName}'.");
+            throw new NotSupportedException($"Unsupported 'endswith' comparison between operands of type '{leftOperand?.GetType().FullName}' and '{rightOperand?.GetType().FullName}'.");
         }
     }
 }

--- a/src/Rules.Framework/Evaluation/ValueEvaluation/EndsWithOperatorEvalStrategy.cs
+++ b/src/Rules.Framework/Evaluation/ValueEvaluation/EndsWithOperatorEvalStrategy.cs
@@ -1,0 +1,20 @@
+namespace Rules.Framework.Evaluation.ValueEvaluation
+{
+    using System;
+
+    internal class EndsWithOperatorEvalStrategy : IOneToOneOperatorEvalStrategy
+    {
+        public bool Eval(object leftOperand, object rightOperand)
+        {
+            if (leftOperand is string)
+            {
+                string leftOperandAsString = leftOperand as string;
+                string rightOperandAsString = rightOperand as string;
+
+                return leftOperandAsString.EndsWith(rightOperandAsString);
+            }
+
+            throw new NotSupportedException($"Unsupported 'startswith' comparison between operands of type '{leftOperand?.GetType().FullName}'.");
+        }
+    }
+}

--- a/src/Rules.Framework/Evaluation/ValueEvaluation/OperatorEvalStrategyFactory.cs
+++ b/src/Rules.Framework/Evaluation/ValueEvaluation/OperatorEvalStrategyFactory.cs
@@ -1,8 +1,8 @@
 namespace Rules.Framework.Evaluation.ValueEvaluation
 {
+    using Rules.Framework.Core;
     using System;
     using System.Collections.Generic;
-    using Rules.Framework.Core;
 
     internal class OperatorEvalStrategyFactory : IOperatorEvalStrategyFactory
     {
@@ -20,6 +20,8 @@ namespace Rules.Framework.Evaluation.ValueEvaluation
                 { Operators.LesserThanOrEqual, new LesserThanOrEqualOperatorEvalStrategy() },
                 { Operators.Contains, new ContainsOperatorEvalStrategy() },
                 { Operators.In, new InOperatorEvalStrategy() },
+                { Operators.StartsWith, new StartsWithOperatorEvalStrategy() },
+                { Operators.EndsWith, new EndsWithOperatorEvalStrategy() },
             };
         }
 

--- a/src/Rules.Framework/Evaluation/ValueEvaluation/StartsWithOperatorEvalStrategy.cs
+++ b/src/Rules.Framework/Evaluation/ValueEvaluation/StartsWithOperatorEvalStrategy.cs
@@ -6,7 +6,7 @@ namespace Rules.Framework.Evaluation.ValueEvaluation
     {
         public bool Eval(object leftOperand, object rightOperand)
         {
-            if (leftOperand is string)
+            if (leftOperand is string && rightOperand is string)
             {
                 string leftOperandAsString = leftOperand as string;
                 string rightOperandAsString = rightOperand as string;
@@ -14,7 +14,7 @@ namespace Rules.Framework.Evaluation.ValueEvaluation
                 return leftOperandAsString.StartsWith(rightOperandAsString);
             }
 
-            throw new NotSupportedException($"Unsupported 'startswith' comparison between operands of type '{leftOperand?.GetType().FullName}'.");
+            throw new NotSupportedException($"Unsupported 'startswith' comparison between operands of type '{leftOperand?.GetType().FullName}' and '{rightOperand?.GetType().FullName}'.");
         }
     }
 }

--- a/src/Rules.Framework/Evaluation/ValueEvaluation/StartsWithOperatorEvalStrategy.cs
+++ b/src/Rules.Framework/Evaluation/ValueEvaluation/StartsWithOperatorEvalStrategy.cs
@@ -1,0 +1,20 @@
+namespace Rules.Framework.Evaluation.ValueEvaluation
+{
+    using System;
+
+    internal class StartsWithOperatorEvalStrategy : IOneToOneOperatorEvalStrategy
+    {
+        public bool Eval(object leftOperand, object rightOperand)
+        {
+            if (leftOperand is string)
+            {
+                string leftOperandAsString = leftOperand as string;
+                string rightOperandAsString = rightOperand as string;
+
+                return leftOperandAsString.StartsWith(rightOperandAsString);
+            }
+
+            throw new NotSupportedException($"Unsupported 'startswith' comparison between operands of type '{leftOperand?.GetType().FullName}'.");
+        }
+    }
+}

--- a/tests/Rules.Framework.Tests/Evaluation/ValueEvaluation/EndsWithOperatorEvalStrategyTests.cs
+++ b/tests/Rules.Framework.Tests/Evaluation/ValueEvaluation/EndsWithOperatorEvalStrategyTests.cs
@@ -5,7 +5,7 @@ namespace Rules.Framework.Tests.Evaluation.ValueEvaluation
     using System;
     using Xunit;
 
-    public class ContainsOperatorEvalStrategyTests
+    public class EndsWithOperatorEvalStrategyTests
     {
         [Fact]
         public void Eval_GivenIntegers1And2_ThrowsNotSupportedException()
@@ -14,7 +14,7 @@ namespace Rules.Framework.Tests.Evaluation.ValueEvaluation
             int expectedLeftOperand = 1;
             int expectedRightOperand = 2;
 
-            ContainsOperatorEvalStrategy sut = new ContainsOperatorEvalStrategy();
+            EndsWithOperatorEvalStrategy sut = new EndsWithOperatorEvalStrategy();
 
             // Act
             NotSupportedException notSupportedException = Assert.Throws<NotSupportedException>(() => sut.Eval(expectedLeftOperand, expectedRightOperand));
@@ -29,9 +29,9 @@ namespace Rules.Framework.Tests.Evaluation.ValueEvaluation
         {
             // Arrange
             string expectedLeftOperand = "The quick brown fox jumps over the lazy dog";
-            string expectedRightOperand = "fox";
+            string expectedRightOperand = "dog";
 
-            ContainsOperatorEvalStrategy sut = new ContainsOperatorEvalStrategy();
+            EndsWithOperatorEvalStrategy sut = new EndsWithOperatorEvalStrategy();
 
             // Act
             bool actual = sut.Eval(expectedLeftOperand, expectedRightOperand);
@@ -41,19 +41,35 @@ namespace Rules.Framework.Tests.Evaluation.ValueEvaluation
         }
 
         [Fact]
-        public void Eval_GivenStringsTheQuickBrownFoxJumpsOverTheLazyDogAndYellow_ReturnsFalse()
+        public void Eval_GivenStringsxpto12345emailpt_ReturnsFalse()
         {
             // Arrange
-            string expectedLeftOperand = "The quick brown fox jumps over the lazy dog";
-            string expectedRightOperand = "yellow";
+            string expectedLeftOperand = "xpto12345@email.pt";
+            string expectedRightOperand = "@email.com";
 
-            ContainsOperatorEvalStrategy sut = new ContainsOperatorEvalStrategy();
+            EndsWithOperatorEvalStrategy sut = new EndsWithOperatorEvalStrategy();
 
             // Act
             bool actual = sut.Eval(expectedLeftOperand, expectedRightOperand);
 
             // Arrange
             actual.Should().BeFalse();
+        }
+
+        [Fact]
+        public void Eval_GivenStringsxpto12345emailpt_ReturnsTrue()
+        {
+            // Arrange
+            string expectedLeftOperand = "xpto12345@email.pt";
+            string expectedRightOperand = "@email.pt";
+
+            EndsWithOperatorEvalStrategy sut = new EndsWithOperatorEvalStrategy();
+
+            // Act
+            bool actual = sut.Eval(expectedLeftOperand, expectedRightOperand);
+
+            // Arrange
+            actual.Should().BeTrue();
         }
     }
 }

--- a/tests/Rules.Framework.Tests/Evaluation/ValueEvaluation/StartsWithOperatorEvalStrategyTests.cs
+++ b/tests/Rules.Framework.Tests/Evaluation/ValueEvaluation/StartsWithOperatorEvalStrategyTests.cs
@@ -5,7 +5,7 @@ namespace Rules.Framework.Tests.Evaluation.ValueEvaluation
     using System;
     using Xunit;
 
-    public class ContainsOperatorEvalStrategyTests
+    public class StartsWithOperatorEvalStrategyTests
     {
         [Fact]
         public void Eval_GivenIntegers1And2_ThrowsNotSupportedException()
@@ -14,7 +14,7 @@ namespace Rules.Framework.Tests.Evaluation.ValueEvaluation
             int expectedLeftOperand = 1;
             int expectedRightOperand = 2;
 
-            ContainsOperatorEvalStrategy sut = new ContainsOperatorEvalStrategy();
+            StartsWithOperatorEvalStrategy sut = new StartsWithOperatorEvalStrategy();
 
             // Act
             NotSupportedException notSupportedException = Assert.Throws<NotSupportedException>(() => sut.Eval(expectedLeftOperand, expectedRightOperand));
@@ -29,9 +29,9 @@ namespace Rules.Framework.Tests.Evaluation.ValueEvaluation
         {
             // Arrange
             string expectedLeftOperand = "The quick brown fox jumps over the lazy dog";
-            string expectedRightOperand = "fox";
+            string expectedRightOperand = "The";
 
-            ContainsOperatorEvalStrategy sut = new ContainsOperatorEvalStrategy();
+            StartsWithOperatorEvalStrategy sut = new StartsWithOperatorEvalStrategy();
 
             // Act
             bool actual = sut.Eval(expectedLeftOperand, expectedRightOperand);
@@ -41,19 +41,35 @@ namespace Rules.Framework.Tests.Evaluation.ValueEvaluation
         }
 
         [Fact]
-        public void Eval_GivenStringsTheQuickBrownFoxJumpsOverTheLazyDogAndYellow_ReturnsFalse()
+        public void Eval_GivenStringsxpto12345emailpt_ReturnsFalse()
         {
             // Arrange
-            string expectedLeftOperand = "The quick brown fox jumps over the lazy dog";
-            string expectedRightOperand = "yellow";
+            string expectedLeftOperand = "xpto12345@email.pt";
+            string expectedRightOperand = "abc";
 
-            ContainsOperatorEvalStrategy sut = new ContainsOperatorEvalStrategy();
+            StartsWithOperatorEvalStrategy sut = new StartsWithOperatorEvalStrategy();
 
             // Act
             bool actual = sut.Eval(expectedLeftOperand, expectedRightOperand);
 
             // Arrange
             actual.Should().BeFalse();
+        }
+
+        [Fact]
+        public void Eval_GivenStringsxpto12345emailpt_ReturnsTrue()
+        {
+            // Arrange
+            string expectedLeftOperand = "xpto12345@email.pt";
+            string expectedRightOperand = "xpto";
+
+            StartsWithOperatorEvalStrategy sut = new StartsWithOperatorEvalStrategy();
+
+            // Act
+            bool actual = sut.Eval(expectedLeftOperand, expectedRightOperand);
+
+            // Arrange
+            actual.Should().BeTrue();
         }
     }
 }


### PR DESCRIPTION
## Description

Adds support for doing `StartsWith` and `EndsWith` comparisons

Closes #55.

## Change checklist

- [x] Code follows the [code rules guidelines](../CONTRIBUTING.md#code-rules) of this project
- [x] Commit messages follow the [commit rules](../CONTRIBUTING.md#commit-rules) of this project
- [x] I have self-reviewed my changes before submitting this pull request
- [x] I have covered new/changed code with new tests and/or adjusted existent ones
- [x] I have made changes necessary to update the documentation accordingly

Please also check the [_I want to contribute_](../CONTRIBUTING.md#i-want-to-contribute) guidelines and make sure you have done accordingly.

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)