### PR TITLE
Adds operator evaluators CaseInsensitiveStartsWith and CaseInsensitiveEndsWith

### DIFF
--- a/docs/add-rules.md
+++ b/docs/add-rules.md
@@ -99,6 +99,8 @@ Next step is to define a comparison operator using method `WithComparisonOperato
 - In
 - StartsWith
 - EndsWith
+- CaseInsensitiveStartsWith
+- CaseInsensitiveEndsWith
 
 Not all comparison operators are supported for all data types, some combinations of them are not valid. This will be validated by rule builder and a validation error will be returned if a invalid combination is attempted. Check the following grid to see combinations are valid or not:
 
@@ -114,6 +116,8 @@ Not all comparison operators are supported for all data types, some combinations
 |In|:heavy_check_mark:|:heavy_check_mark:|:x:|:heavy_check_mark:|
 |StartsWith|:x:|:x:|:x:|:heavy_check_mark:|
 |EndsWith|:x:|:x:|:x:|:heavy_check_mark:|
+|CaseInsensitiveStartsWith|:x:|:x:|:x:|:heavy_check_mark:|
+|CaseInsensitiveEndsWith|:x:|:x:|:x:|:heavy_check_mark:|
 
 You should also take into consideration the multiplicity of operands when setting value conditions on a rule. Theoretically, all multiplicity combinations are supported (one to one, one to many, many to one, many to many), but that also relies on a per-operator implementation for each multiplicity. Please refer to following combinations to see which multiplicities are supported or not:
 
@@ -129,6 +133,8 @@ You should also take into consideration the multiplicity of operands when settin
 |In|:x:|:heavy_check_mark:|:x:|:x:|
 |StartsWith|:heavy_check_mark:|:x:|:x:|:x:|
 |EndsWith|:heavy_check_mark:|:x:|:x:|:x:|
+|CaseInsensitiveStartsWith|:heavy_check_mark:|:x:|:x:|:x:|
+|CaseInsensitiveEndsWith|:heavy_check_mark:|:x:|:x:|:x:|
 
 At last, you should complete valued condition node build with a right hand operand with following methods, according to wanted multiplicity:
 

--- a/src/Rules.Framework/Builder/Validation/ValueConditionNodeValidator.cs
+++ b/src/Rules.Framework/Builder/Validation/ValueConditionNodeValidator.cs
@@ -1,9 +1,9 @@
 namespace Rules.Framework.Builder.Validation
 {
+    using System.Collections.Generic;
     using FluentValidation;
     using Rules.Framework.Core;
     using Rules.Framework.Core.ConditionNodes;
-    using System.Collections.Generic;
 
     internal class ValueConditionNodeValidator<TConditionType> : AbstractValidator<ValueConditionNode<TConditionType>>
     {
@@ -19,7 +19,7 @@ namespace Rules.Framework.Builder.Validation
             this.RuleFor(c => c.Operator).IsInEnum();
 
             this.RuleFor(c => c.Operator)
-                .IsContainedOn(Operators.Equal, Operators.NotEqual, Operators.Contains, Operators.In, Operators.StartsWith, Operators.EndsWith)
+                .IsContainedOn(Operators.Equal, Operators.NotEqual, Operators.Contains, Operators.In, Operators.StartsWith, Operators.EndsWith, Operators.CaseInsensitiveStartsWith, Operators.CaseInsensitiveEndsWith)
                 .When(c => c.DataType == DataTypes.String)
                 .WithMessage(cn => $"Condition nodes with data type '{cn.DataType}' can't define a operator of type '{cn.Operator}'.");
 

--- a/src/Rules.Framework/Core/Operators.cs
+++ b/src/Rules.Framework/Core/Operators.cs
@@ -55,6 +55,16 @@ namespace Rules.Framework.Core
         /// <summary>
         /// The ends with operator.
         /// </summary>
-        EndsWith = 11
+        EndsWith = 11,
+
+        /// <summary>
+        /// The starts with operator.
+        /// </summary>
+        CaseInsensitiveStartsWith = 12,
+
+        /// <summary>
+        /// The ends with operator.
+        /// </summary>
+        CaseInsensitiveEndsWith = 13
     }
 }

--- a/src/Rules.Framework/Evaluation/ValueEvaluation/CaseInsensitiveEndsWithOperatorEvalStrategy.cs
+++ b/src/Rules.Framework/Evaluation/ValueEvaluation/CaseInsensitiveEndsWithOperatorEvalStrategy.cs
@@ -1,0 +1,21 @@
+namespace Rules.Framework.Evaluation.ValueEvaluation
+{
+    using System;
+    using System.Globalization;
+
+    internal class CaseInsensitiveEndsWithOperatorEvalStrategy : IOneToOneOperatorEvalStrategy
+    {
+        public bool Eval(object leftOperand, object rightOperand)
+        {
+            if (leftOperand is string && rightOperand is string)
+            {
+                string leftOperandAsString = leftOperand as string;
+                string rightOperandAsString = rightOperand as string;
+
+                return leftOperandAsString.EndsWith(rightOperandAsString, ignoreCase: true, culture: CultureInfo.InvariantCulture);
+            }
+
+            throw new NotSupportedException($"Unsupported 'caseinsensitiveendswith' comparison between operands of type '{leftOperand?.GetType().FullName}' and '{rightOperand?.GetType().FullName}'.");
+        }
+    }
+}

--- a/src/Rules.Framework/Evaluation/ValueEvaluation/CaseInsensitiveStartsWithOperatorEvalStrategy.cs
+++ b/src/Rules.Framework/Evaluation/ValueEvaluation/CaseInsensitiveStartsWithOperatorEvalStrategy.cs
@@ -1,0 +1,21 @@
+namespace Rules.Framework.Evaluation.ValueEvaluation
+{
+    using System;
+    using System.Globalization;
+
+    internal class CaseInsensitiveStartsWithOperatorEvalStrategy : IOneToOneOperatorEvalStrategy
+    {
+        public bool Eval(object leftOperand, object rightOperand)
+        {
+            if (leftOperand is string && rightOperand is string)
+            {
+                string leftOperandAsString = leftOperand as string;
+                string rightOperandAsString = rightOperand as string;
+
+                return leftOperandAsString.StartsWith(rightOperandAsString, ignoreCase: true, culture: CultureInfo.InvariantCulture);
+            }
+
+            throw new NotSupportedException($"Unsupported 'caseinsensitivestartswith' comparison between operands of type '{leftOperand?.GetType().FullName}' and '{rightOperand?.GetType().FullName}'.");
+        }
+    }
+}

--- a/src/Rules.Framework/Evaluation/ValueEvaluation/Dispatchers/ConditionEvalDispatchProvider.cs
+++ b/src/Rules.Framework/Evaluation/ValueEvaluation/Dispatchers/ConditionEvalDispatchProvider.cs
@@ -1,10 +1,10 @@
 namespace Rules.Framework.Evaluation.ValueEvaluation.Dispatchers
 {
-    using Rules.Framework.Core;
     using System;
     using System.Collections;
     using System.Collections.Generic;
     using System.Linq;
+    using Rules.Framework.Core;
 
     internal class ConditionEvalDispatchProvider : IConditionEvalDispatchProvider
     {
@@ -38,6 +38,8 @@ namespace Rules.Framework.Evaluation.ValueEvaluation.Dispatchers
                 $"{OneToMany}-{Operators.In}",
                 $"{OneToOne}-{Operators.StartsWith}",
                 $"{OneToOne}-{Operators.EndsWith}",
+                $"{OneToOne}-{Operators.CaseInsensitiveStartsWith}",
+                $"{OneToOne}-{Operators.CaseInsensitiveEndsWith}"
             };
         }
 

--- a/src/Rules.Framework/Evaluation/ValueEvaluation/OperatorEvalStrategyFactory.cs
+++ b/src/Rules.Framework/Evaluation/ValueEvaluation/OperatorEvalStrategyFactory.cs
@@ -1,8 +1,8 @@
 namespace Rules.Framework.Evaluation.ValueEvaluation
 {
-    using Rules.Framework.Core;
     using System;
     using System.Collections.Generic;
+    using Rules.Framework.Core;
 
     internal class OperatorEvalStrategyFactory : IOperatorEvalStrategyFactory
     {
@@ -22,6 +22,8 @@ namespace Rules.Framework.Evaluation.ValueEvaluation
                 { Operators.In, new InOperatorEvalStrategy() },
                 { Operators.StartsWith, new StartsWithOperatorEvalStrategy() },
                 { Operators.EndsWith, new EndsWithOperatorEvalStrategy() },
+                { Operators.CaseInsensitiveStartsWith, new CaseInsensitiveStartsWithOperatorEvalStrategy() },
+                { Operators.CaseInsensitiveEndsWith, new CaseInsensitiveEndsWithOperatorEvalStrategy() }
             };
         }
 

--- a/tests/Rules.Framework.Tests/Evaluation/ValueEvaluation/CaseInsensitiveEndsWithOperatorEvalStrategyTests.cs
+++ b/tests/Rules.Framework.Tests/Evaluation/ValueEvaluation/CaseInsensitiveEndsWithOperatorEvalStrategyTests.cs
@@ -1,0 +1,59 @@
+namespace Rules.Framework.Tests.Evaluation.ValueEvaluation
+{
+    using System;
+    using FluentAssertions;
+    using Rules.Framework.Evaluation.ValueEvaluation;
+    using Xunit;
+
+    public class CaseInsensitiveEndsWithOperatorEvalStrategyTests
+    {
+        [Fact]
+        public void Eval_GivenIntegers1And2_ThrowsNotSupportedException()
+        {
+            // Arrange
+            int expectedLeftOperand = 1;
+            int expectedRightOperand = 2;
+
+            CaseInsensitiveEndsWithOperatorEvalStrategy sut = new CaseInsensitiveEndsWithOperatorEvalStrategy();
+
+            // Act
+            NotSupportedException notSupportedException = Assert.Throws<NotSupportedException>(() => sut.Eval(expectedLeftOperand, expectedRightOperand));
+
+            // Assert
+            notSupportedException.Should().NotBeNull();
+            notSupportedException.Message.Should().Contain("System.Int32");
+        }
+
+        [Theory]
+        [InlineData("Random Message One Two Three", "Threee")]
+        [InlineData("Random Message One Two Three", "Random")]
+        [InlineData("Random Message One Two Three", "The")]
+        public void Eval_GivenStringsRandomMessageOneTwoThree_ReturnsFalse(string expectedLeftOperand, string expectedRightOperand)
+        {
+            // Arrange
+            CaseInsensitiveEndsWithOperatorEvalStrategy sut = new CaseInsensitiveEndsWithOperatorEvalStrategy();
+
+            // Act
+            bool actual = sut.Eval(expectedLeftOperand, expectedRightOperand);
+
+            // Assert
+            actual.Should().BeFalse();
+        }
+
+        [Theory]
+        [InlineData("The quick brown fox jumps over the lazy dog", "dog")]
+        [InlineData("The quick brown fox jumps over the lazy Dog", "dog")]
+        [InlineData("The quick brown fox jumps over the lazy dog", "Dog")]
+        public void Eval_GivenStringsTheQuickBrownFoxJumpsOverTheLazyDogAndFox_CaseInsensitive_ReturnsTrue(string expectedLeftOperand, string expectedRightOperand)
+        {
+            // Arrange
+            CaseInsensitiveEndsWithOperatorEvalStrategy sut = new CaseInsensitiveEndsWithOperatorEvalStrategy();
+
+            // Act
+            bool actual = sut.Eval(expectedLeftOperand, expectedRightOperand);
+
+            // Assert
+            actual.Should().BeTrue();
+        }
+    }
+}

--- a/tests/Rules.Framework.Tests/Evaluation/ValueEvaluation/CaseInsensitiveStartsWithOperatorEvalStrategyTests.cs
+++ b/tests/Rules.Framework.Tests/Evaluation/ValueEvaluation/CaseInsensitiveStartsWithOperatorEvalStrategyTests.cs
@@ -1,0 +1,59 @@
+namespace Rules.Framework.Tests.Evaluation.ValueEvaluation
+{
+    using System;
+    using FluentAssertions;
+    using Rules.Framework.Evaluation.ValueEvaluation;
+    using Xunit;
+
+    public class CaseInsensitiveStartsWithOperatorEvalStrategyTests
+    {
+        [Fact]
+        public void Eval_GivenIntegers1And2_ThrowsNotSupportedException()
+        {
+            // Arrange
+            int expectedLeftOperand = 1;
+            int expectedRightOperand = 2;
+
+            CaseInsensitiveStartsWithOperatorEvalStrategy sut = new CaseInsensitiveStartsWithOperatorEvalStrategy();
+
+            // Act
+            NotSupportedException notSupportedException = Assert.Throws<NotSupportedException>(() => sut.Eval(expectedLeftOperand, expectedRightOperand));
+
+            // Assert
+            notSupportedException.Should().NotBeNull();
+            notSupportedException.Message.Should().Contain("System.Int32");
+        }
+
+        [Theory]
+        [InlineData("Random Message One Two Three", "Message")]
+        [InlineData("Random Message One Two Three", "Randmo")]
+        [InlineData("Random Message One Two Three", "The")]
+        public void Eval_GivenStringsRandomMessageOneTwoThree_ReturnsFalse(string expectedLeftOperand, string expectedRightOperand)
+        {
+            // Arrange
+            CaseInsensitiveStartsWithOperatorEvalStrategy sut = new CaseInsensitiveStartsWithOperatorEvalStrategy();
+
+            // Act
+            bool actual = sut.Eval(expectedLeftOperand, expectedRightOperand);
+
+            // Assert
+            actual.Should().BeFalse();
+        }
+
+        [Theory]
+        [InlineData("The quick brown fox jumps over the lazy dog", "The")]
+        [InlineData("the quick brown fox jumps over the lazy dog", "The")]
+        [InlineData("The quick brown fox jumps over the lazy dog", "the")]
+        public void Eval_GivenStringsTheQuickBrownFoxJumpsOverTheLazyDog_CaseInsensitive_ReturnsTrue(string expectedLeftOperand, string expectedRightOperand)
+        {
+            // Arrange
+            CaseInsensitiveStartsWithOperatorEvalStrategy sut = new CaseInsensitiveStartsWithOperatorEvalStrategy();
+
+            // Act
+            bool actual = sut.Eval(expectedLeftOperand, expectedRightOperand);
+
+            // Assert
+            actual.Should().BeTrue();
+        }
+    }
+}


### PR DESCRIPTION
## Description

Adds operator evaluators CaseInsensitiveStartsWith and CaseInsensitiveEndsWith.

Closes #57. 

## Change checklist

- [x] Code follows the [code rules guidelines](../CONTRIBUTING.md#code-rules) of this project
- [x] Commit messages follow the [commit rules](../CONTRIBUTING.md#commit-rules) of this project
- [x] I have self-reviewed my changes before submitting this pull request
- [x] I have covered new/changed code with new tests and/or adjusted existent ones
- [x] I have made changes necessary to update the documentation accordingly

Please also check the [_I want to contribute_](../CONTRIBUTING.md#i-want-to-contribute) guidelines and make sure you have done accordingly.

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)