### PR TITLE
[BUG #50]Implemented Solution and Unit Test

### DIFF
--- a/src/Rules.Framework/RulesEngine.cs
+++ b/src/Rules.Framework/RulesEngine.cs
@@ -228,7 +228,8 @@ namespace Rules.Framework
                     break;
 
                 case PriorityOptions.AtBottom:
-                    rule.Priority = existentRules.Max(r => r.Priority) + 1;
+
+                    rule.Priority = !existentRules.Any() ? 1 : existentRules.Max(r => r.Priority) + 1;
 
                     await ManagementOperations.Manage(existentRules)
                         .UsingDataSource(this.rulesDataSource)


### PR DESCRIPTION
## Description

Inserting rules AtBottom causes exception when rules data source is empty for a ContentType 

Closes #50.

## Change checklist

- [X ] Code follows the [code rules guidelines](../CONTRIBUTING.md#code-rules) of this project
- [X ] Commit messages follow the [commit rules](../CONTRIBUTING.md#commit-rules) of this project
- [ X] I have self-reviewed my changes before submitting this pull request
- [X ] I have covered new/changed code with new tests and/or adjusted existent ones
- [X ] I have made changes necessary to update the documentation accordingly