### PR TITLE
Implemented GetConditionType method and unit test

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,14 +76,14 @@ If you request a rule for the content type "Body Mass formula" by specifying dat
 
 ## Using the framework
 
-1. [Getting started](docs/getting-started.md)
-2. [Add rules](docs/add-rules.md)
-3. [Update rules](docs/update-rules.md)
-4. [Search rules](docs/search-rules.md)
-5. [Get Unique Condition Types](get-unique-condition-types.md)
-6. [In-memory data source provider](docs/using-in-memory-data-source.md)
-7. [MongoDB data source provider](docs/using-mongo-db-data-source.md)
-8. [New data source provider - How To](docs/new-data-source-how-to.md)
+1.  [Getting started](docs/getting-started.md)
+2.  [Add rules](docs/add-rules.md)
+3.  [Update rules](docs/update-rules.md)
+4.  [Search rules](docs/search-rules.md)
+5.  [Get Unique Condition Types](get-unique-condition-types.md)
+6.  [In-memory data source provider](docs/using-in-memory-data-source.md)
+7.  [MongoDB data source provider](docs/using-mongo-db-data-source.md)
+8.  [New data source provider - How To](docs/new-data-source-how-to.md)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ If you request a rule for the content type "Body Mass formula" by specifying dat
 1. [Add rules](docs/add-rules.md)
 1. [Update rules](docs/update-rules.md)
 1. [Search rules](docs/search-rules.md)
+1. [Get Unique Condition Types](get-unique-condition-types.md)
 1. [In-memory data source provider](docs/using-in-memory-data-source.md)
 1. [MongoDB data source provider](docs/using-mongo-db-data-source.md)
 1. [New data source provider - How To](docs/new-data-source-how-to.md)

--- a/README.md
+++ b/README.md
@@ -77,13 +77,13 @@ If you request a rule for the content type "Body Mass formula" by specifying dat
 ## Using the framework
 
 1. [Getting started](docs/getting-started.md)
-1. [Add rules](docs/add-rules.md)
-1. [Update rules](docs/update-rules.md)
-1. [Search rules](docs/search-rules.md)
-1. [Get Unique Condition Types](get-unique-condition-types.md)
-1. [In-memory data source provider](docs/using-in-memory-data-source.md)
-1. [MongoDB data source provider](docs/using-mongo-db-data-source.md)
-1. [New data source provider - How To](docs/new-data-source-how-to.md)
+2. [Add rules](docs/add-rules.md)
+3. [Update rules](docs/update-rules.md)
+4. [Search rules](docs/search-rules.md)
+5. [Get Unique Condition Types](get-unique-condition-types.md)
+6. [In-memory data source provider](docs/using-in-memory-data-source.md)
+7. [MongoDB data source provider](docs/using-mongo-db-data-source.md)
+8. [New data source provider - How To](docs/new-data-source-how-to.md)
 
 ## Contributing
 

--- a/docs/get-unique-condition-types.md
+++ b/docs/get-unique-condition-types.md
@@ -1,0 +1,17 @@
+# Get Unique Condition Types
+
+This page focus on how to get the condition types  associated with rules of a specific content type using Rules.Framework.
+
+## The `GetUniqueConditionsTypes` Method
+
+Get the unique condition types associated with rules of a specific content type and period.
+
+```csharp
+GetUniqueConditionTypesAsync(TContentType contentType, DateTime dateBegin, DateTime dateEnd)
+```
+A set of rules is requested to rules data source and all conditions are evaluated against them to provide a set of matches. All rules matching supplied conditions are returned.
+
+```csharp
+GetConditionTypes(IEnumerable<Rule<TContentType, TConditionType>> matchedRules)
+```
+If no conditions are found an empty list is returned

--- a/src/Rules.Framework.Providers.InMemory/Rules.Framework.Providers.InMemory.csproj
+++ b/src/Rules.Framework.Providers.InMemory/Rules.Framework.Providers.InMemory.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>9.0</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Authors></Authors>
     <Version></Version>

--- a/src/Rules.Framework.Providers.MongoDb/Rules.Framework.Providers.MongoDb.csproj
+++ b/src/Rules.Framework.Providers.MongoDb/Rules.Framework.Providers.MongoDb.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>9.0</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Authors></Authors>
     <Version></Version>

--- a/src/Rules.Framework/Builder/ConfiguredRulesEngineBuilder.cs
+++ b/src/Rules.Framework/Builder/ConfiguredRulesEngineBuilder.cs
@@ -20,13 +20,21 @@ namespace Rules.Framework.Builder
         public RulesEngine<TContentType, TConditionType> Build()
         {
             IOperatorEvalStrategyFactory operatorEvalStrategyFactory = new OperatorEvalStrategyFactory();
+
             IDataTypesConfigurationProvider dataTypesConfigurationProvider = new DataTypesConfigurationProvider(this.rulesEngineOptions);
+
             IConditionEvalDispatchProvider conditionEvalDispatchProvider = new ConditionEvalDispatchProvider(operatorEvalStrategyFactory, dataTypesConfigurationProvider);
+
             IDeferredEval deferredEval = new DeferredEval(conditionEvalDispatchProvider, this.rulesEngineOptions);
+
             IConditionsEvalEngine<TConditionType> conditionsEvalEngine = new ConditionsEvalEngine<TConditionType>(deferredEval);
+
+            IConditionTypeExtractor<TContentType, TConditionType> conditionTypeExtractor = new ConditionTypeExtractor<TContentType, TConditionType>();
+
             ValidationProvider validationProvider = ValidationProvider.New()
                 .MapValidatorFor(new SearchArgsValidator<TContentType, TConditionType>());
-            return new RulesEngine<TContentType, TConditionType>(conditionsEvalEngine, this.rulesDataSource, validationProvider, this.rulesEngineOptions);
+
+            return new RulesEngine<TContentType, TConditionType>(conditionsEvalEngine, this.rulesDataSource, validationProvider, this.rulesEngineOptions, conditionTypeExtractor);
         }
 
         public IConfiguredRulesEngineBuilder<TContentType, TConditionType> Configure(Action<RulesEngineOptions> configurationAction)

--- a/src/Rules.Framework/ConditionTypeExtractor.cs
+++ b/src/Rules.Framework/ConditionTypeExtractor.cs
@@ -1,0 +1,50 @@
+namespace Rules.Framework
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using Rules.Framework.Core;
+
+    /// <summary>
+    /// Extracts Conditions Types from a Group of Rules.
+    /// </summary>
+    /// <typeparam name="TContentType">The content type that allows to categorize rules.</typeparam>
+    /// <typeparam name="TConditionType">
+    /// The condition type that allows to filter rules based on a set of conditions.
+    /// </typeparam>
+    public class ConditionTypeExtractor<TContentType, TConditionType> : IConditionTypeExtractor<TContentType, TConditionType>
+    {
+        /// <summary>
+        /// Get the unique condition types associated with rules of a specific content type/>.
+        /// </summary>
+        /// <param name="matchedRules"></param>
+        /// <remarks>
+        /// <para>
+        /// A set of rules is requested to rules data source and all conditions are evaluated
+        /// against them to provide a set of matches.
+        /// </para>
+        /// <para>All rules matching supplied conditions are returned.</para>
+        /// </remarks>
+        /// <returns>the matched rule; otherwise, null.</returns>
+        public IEnumerable<TConditionType> GetConditionTypes(IEnumerable<Rule<TContentType, TConditionType>> matchedRules)
+        {
+            var conditionTypes = new List<TConditionType>();
+
+            if (!matchedRules.Any())
+            {
+                return conditionTypes;
+            }
+
+            foreach (var rule in matchedRules)
+            {
+                var conditionType = rule.ContentContainer.GetContentAs<TConditionType>();
+
+                if (!conditionTypes.Contains(conditionType))
+                {
+                    conditionTypes.Add(conditionType);
+                }
+            }
+
+            return conditionTypes;
+        }
+    }
+}

--- a/src/Rules.Framework/ConditionTypeExtractor.cs
+++ b/src/Rules.Framework/ConditionTypeExtractor.cs
@@ -15,7 +15,7 @@ namespace Rules.Framework
     /// </typeparam>
     public class ConditionTypeExtractor<TContentType, TConditionType> : IConditionTypeExtractor<TContentType, TConditionType>
     {
-        private readonly List<Type> allowedExceptions = new List<Type>()
+        private readonly List<Type> allowedExceptions = new List<Type>
         {
             typeof(NotSupportedException),
             typeof(NullReferenceException)

--- a/src/Rules.Framework/ConditionTypeExtractor.cs
+++ b/src/Rules.Framework/ConditionTypeExtractor.cs
@@ -15,12 +15,6 @@ namespace Rules.Framework
     /// </typeparam>
     public class ConditionTypeExtractor<TContentType, TConditionType> : IConditionTypeExtractor<TContentType, TConditionType>
     {
-        private readonly List<Type> allowedExceptions = new List<Type>
-        {
-            typeof(NotSupportedException),
-            typeof(NullReferenceException)
-        };
-
         /// <summary>
         /// Get the unique condition types associated with rules of a specific content type.
         /// </summary>
@@ -46,19 +40,12 @@ namespace Rules.Framework
             {
                 var rootCondition = rule.RootCondition;
 
-                try
+                if (rootCondition is null)
                 {
-                    VisitConditionNode(rootCondition, conditionTypes);
+                    continue;
                 }
-                catch (Exception ex)
-                {
-                    if (allowedExceptions.Contains(ex.GetType()))
-                    {
-                        continue;
-                    }
 
-                    throw;
-                }
+                VisitConditionNode(rootCondition, conditionTypes);
             }
 
             return conditionTypes;

--- a/src/Rules.Framework/ConditionTypeExtractor.cs
+++ b/src/Rules.Framework/ConditionTypeExtractor.cs
@@ -38,9 +38,9 @@ namespace Rules.Framework
 
             foreach (var rule in matchedRules)
             {
-                var rootCondtion = rule.RootCondition;
+                var rootCondition = rule.RootCondition;
 
-                VisitConditionNode(rootCondtion, conditionTypes);
+                VisitConditionNode(rootCondition, conditionTypes);
             }
 
             return conditionTypes;

--- a/src/Rules.Framework/ConditionTypeExtractor.cs
+++ b/src/Rules.Framework/ConditionTypeExtractor.cs
@@ -32,7 +32,7 @@ namespace Rules.Framework
         /// </para>
         /// <para>All rules matching supplied conditions are returned.</para>
         /// </remarks>
-        /// <returns>the matched rule; otherwise, null.</returns>
+        /// <returns>the matched rule; otherwise, empty.</returns>
         public IEnumerable<TConditionType> GetConditionTypes(IEnumerable<Rule<TContentType, TConditionType>> matchedRules)
         {
             var conditionTypes = new HashSet<TConditionType>();

--- a/src/Rules.Framework/IConditionTypeExtractor.cs
+++ b/src/Rules.Framework/IConditionTypeExtractor.cs
@@ -1,0 +1,29 @@
+namespace Rules.Framework
+{
+    using System.Collections.Generic;
+    using Rules.Framework.Core;
+
+    /// <summary>
+    /// Extracts Conditions Types from a Group of Rules.
+    /// </summary>
+    /// <typeparam name="TContentType">The content type that allows to categorize rules.</typeparam>
+    /// <typeparam name="TConditionType">
+    /// The condition type that allows to filter rules based on a set of conditions.
+    /// </typeparam>
+    public interface IConditionTypeExtractor<TContentType, TConditionType>
+    {
+        /// <summary>
+        /// Get the unique condition types associated with rules of a specific content type/>.
+        /// </summary>
+        /// <param name="matchedRules"></param>
+        /// <remarks>
+        /// <para>
+        /// A set of rules is requested to rules data source and all conditions are evaluated
+        /// against them to provide a set of matches.
+        /// </para>
+        /// <para>All rules matching supplied conditions are returned.</para>
+        /// </remarks>
+        /// <returns>the matched rule; otherwise, null.</returns>
+        IEnumerable<TConditionType> GetConditionTypes(IEnumerable<Rule<TContentType, TConditionType>> matchedRules);
+    }
+}

--- a/src/Rules.Framework/IConditionTypeExtractor.cs
+++ b/src/Rules.Framework/IConditionTypeExtractor.cs
@@ -13,7 +13,7 @@ namespace Rules.Framework
     public interface IConditionTypeExtractor<TContentType, TConditionType>
     {
         /// <summary>
-        /// Get the unique condition types associated with rules of a specific content type/>.
+        /// Get the unique condition types associated with rules of a specific content type.
         /// </summary>
         /// <param name="matchedRules"></param>
         /// <remarks>

--- a/src/Rules.Framework/Rules.Framework.csproj
+++ b/src/Rules.Framework/Rules.Framework.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>9.0</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Authors></Authors>
     <Version></Version>

--- a/src/Rules.Framework/RulesEngine.cs
+++ b/src/Rules.Framework/RulesEngine.cs
@@ -68,7 +68,7 @@ namespace Rules.Framework
         }
 
         /// <summary>
-        /// Get the unique condition types associated with rules of a specific content type/>.
+        /// Get the unique condition types associated with rules of a specific content type.
         /// </summary>
         /// <param name="contentType"></param>
         /// <param name="dateBegin"></param>

--- a/src/Rules.Framework/RulesEngine.cs
+++ b/src/Rules.Framework/RulesEngine.cs
@@ -80,7 +80,7 @@ namespace Rules.Framework
         /// </para>
         /// <para>All rules matching supplied conditions are returned.</para>
         /// </remarks>
-        /// <returns>the matched rule; otherwise, null.</returns>
+        /// <returns>the matched rule; otherwise, empty.</returns>
         public async Task<IEnumerable<TConditionType>> GetUniqueConditionTypesAsync(TContentType contentType, DateTime dateBegin, DateTime dateEnd)
         {
             var matchedRules = await this.rulesDataSource.GetRulesAsync(contentType, dateBegin, dateEnd).ConfigureAwait(false);

--- a/src/Rules.Framework/RulesEngine.cs
+++ b/src/Rules.Framework/RulesEngine.cs
@@ -65,6 +65,39 @@ namespace Rules.Framework
         }
 
         /// <summary>
+        /// PGet the unique condition types associated with rules of a specific content type/>.
+        /// </summary>
+        /// <param name="contentType"></param>
+        /// <param name="dateBegin"></param>
+        /// <param name="dateEnd"></param>
+        /// <remarks>
+        /// <para>
+        /// A set of rules is requested to rules data source and all conditions are evaluated
+        /// against them to provide a set of matches.
+        /// </para>
+        /// <para>All rules matching supplied conditions are returned.</para>
+        /// </remarks>
+        /// <returns>the matched rule; otherwise, null.</returns>
+        public async Task<IEnumerable<IConditionNode<TConditionType>>> GetUniqueConditionTypesAsync(TContentType contentType, DateTime dateBegin, DateTime dateEnd)
+        {
+            var matchedRules = await this.rulesDataSource.GetRulesAsync(contentType, dateBegin, dateEnd).ConfigureAwait(false);
+
+            var conditionTypes = new List<IConditionNode<TConditionType>>();
+
+            if (!matchedRules.Any())
+            {
+                return conditionTypes;
+            }
+
+            foreach (var rule in matchedRules)
+            {
+                conditionTypes.Add(rule.RootCondition);
+            }
+
+            return conditionTypes;
+        }
+
+        /// <summary>
         /// Provides all rule matches (if any) to the given content type at the specified <paramref
         /// name="matchDateTime"/> and satisfying the supplied <paramref name="conditions"/>.
         /// </summary>

--- a/tests/Rules.Framework.IntegrationTests/Rules.Framework.IntegrationTests.csproj
+++ b/tests/Rules.Framework.IntegrationTests/Rules.Framework.IntegrationTests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>9.0</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/tests/Rules.Framework.Providers.InMemory.Tests/Rules.Framework.Providers.InMemory.Tests.csproj
+++ b/tests/Rules.Framework.Providers.InMemory.Tests/Rules.Framework.Providers.InMemory.Tests.csproj
@@ -1,11 +1,11 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
 
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Rules.Framework.Providers.MongoDb.IntegrationTests/Rules.Framework.Providers.MongoDb.IntegrationTests.csproj
+++ b/tests/Rules.Framework.Providers.MongoDb.IntegrationTests/Rules.Framework.Providers.MongoDb.IntegrationTests.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Rules.Framework.Providers.MongoDb.Tests/Rules.Framework.Providers.MongoDb.Tests.csproj
+++ b/tests/Rules.Framework.Providers.MongoDb.Tests/Rules.Framework.Providers.MongoDb.Tests.csproj
@@ -5,7 +5,7 @@
 
     <IsPackable>false</IsPackable>
 
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Rules.Framework.Tests/ConditionTypeExtractorTests.cs
+++ b/tests/Rules.Framework.Tests/ConditionTypeExtractorTests.cs
@@ -22,7 +22,7 @@ namespace Rules.Framework.Tests
 
             var rule1 = new Rule<ContentType, ConditionType>
             {
-                ContentContainer = new ContentContainer<ContentType>(contentType, (t) => new object()),
+                ContentContainer = new ContentContainer<ContentType>(contentType, _ => new object()),
                 DateBegin = dateBegin,
                 DateEnd = dateEnd,
                 Name = "Rule 1",
@@ -32,7 +32,7 @@ namespace Rules.Framework.Tests
 
             var rule2 = new Rule<ContentType, ConditionType>
             {
-                ContentContainer = new ContentContainer<ContentType>(contentType, (t) => new object()),
+                ContentContainer = new ContentContainer<ContentType>(contentType, _ => new object()),
                 DateBegin = new DateTime(2020, 01, 01),
                 DateEnd = new DateTime(2021, 01, 01),
                 Name = "Rule 2",
@@ -42,7 +42,7 @@ namespace Rules.Framework.Tests
 
             var rule3 = new Rule<ContentType, ConditionType>
             {
-                ContentContainer = new ContentContainer<ContentType>(contentType, (t) => new object()),
+                ContentContainer = new ContentContainer<ContentType>(contentType, _ => new object()),
                 DateBegin = dateBegin,
                 DateEnd = dateEnd,
                 Name = "Rule 3",
@@ -52,7 +52,7 @@ namespace Rules.Framework.Tests
 
             var rule4 = new Rule<ContentType, ConditionType>
             {
-                ContentContainer = new ContentContainer<ContentType>(contentType, (t) => new object()),
+                ContentContainer = new ContentContainer<ContentType>(contentType, _ => new object()),
                 DateBegin = dateBegin,
                 DateEnd = dateEnd,
                 Name = "Rule 4",
@@ -76,7 +76,7 @@ namespace Rules.Framework.Tests
                 rule4
             };
 
-            var expectedConditionTypeList = new List<ConditionType>()
+            var expectedConditionTypeList = new List<ConditionType>
             {
                 ConditionType.IsoCurrency,
                 ConditionType.IsoCountryCode,

--- a/tests/Rules.Framework.Tests/ConditionTypeExtractorTests.cs
+++ b/tests/Rules.Framework.Tests/ConditionTypeExtractorTests.cs
@@ -27,7 +27,7 @@ namespace Rules.Framework.Tests
                 DateEnd = dateEnd,
                 Name = "Rule 1",
                 Priority = 3,
-                RootCondition = new StringConditionNode<ConditionType>(ConditionType.IsoCountryCode, Operators.Equal, "USA")
+                RootCondition = new ValueConditionNode<ConditionType>(DataTypes.String, ConditionType.IsoCountryCode, Operators.Equal, "USA")
             };
 
             var rule2 = new Rule<ContentType, ConditionType>
@@ -37,7 +37,7 @@ namespace Rules.Framework.Tests
                 DateEnd = new DateTime(2021, 01, 01),
                 Name = "Rule 2",
                 Priority = 200,
-                RootCondition = new StringConditionNode<ConditionType>(ConditionType.IsoCountryCode, Operators.Equal, "USA")
+                RootCondition = new ValueConditionNode<ConditionType>(DataTypes.String, ConditionType.IsoCountryCode, Operators.Equal, "USA")
             };
 
             var rule3 = new Rule<ContentType, ConditionType>
@@ -47,7 +47,7 @@ namespace Rules.Framework.Tests
                 DateEnd = dateEnd,
                 Name = "Rule 3",
                 Priority = 1,
-                RootCondition = new StringConditionNode<ConditionType>(ConditionType.IsoCurrency, Operators.Equal, "EUR")
+                RootCondition = new ValueConditionNode<ConditionType>(DataTypes.String, ConditionType.IsoCurrency, Operators.Equal, "EUR")
             };
 
             var rule4 = new Rule<ContentType, ConditionType>
@@ -61,9 +61,9 @@ namespace Rules.Framework.Tests
                 LogicalOperators.And,
                 new IConditionNode<ConditionType>[]
                 {
-                    new StringConditionNode<ConditionType>(ConditionType.IsVip, Operators.Equal, "true"),
-                    new StringConditionNode<ConditionType>(ConditionType.PluviosityRate, Operators.Equal, "15"),
-                    new StringConditionNode<ConditionType>(ConditionType.IsoCurrency, Operators.Equal, "JPY")
+                    new ValueConditionNode<ConditionType>(DataTypes.String,ConditionType.IsVip, Operators.Equal, "true"),
+                    new ValueConditionNode<ConditionType>(DataTypes.String,ConditionType.PluviosityRate, Operators.Equal, "15"),
+                    new ValueConditionNode<ConditionType>(DataTypes.String,ConditionType.IsoCurrency, Operators.Equal, "JPY")
                 }
                 )
             };

--- a/tests/Rules.Framework.Tests/ConditionTypeExtractorTests.cs
+++ b/tests/Rules.Framework.Tests/ConditionTypeExtractorTests.cs
@@ -15,12 +15,12 @@ namespace Rules.Framework.Tests
         {
             // Arrange
 
-            DateTime dateBegin = new DateTime(2018, 01, 01);
-            DateTime dateEnd = new DateTime(2019, 01, 01);
+            var dateBegin = new DateTime(2018, 01, 01);
+            var dateEnd = new DateTime(2019, 01, 01);
 
-            ContentType contentType = ContentType.Type1;
+            var contentType = ContentType.Type1;
 
-            Rule<ContentType, ConditionType> rule1 = new Rule<ContentType, ConditionType>
+            var rule1 = new Rule<ContentType, ConditionType>
             {
                 ContentContainer = new ContentContainer<ContentType>(contentType, (t) => new object()),
                 DateBegin = dateBegin,
@@ -30,7 +30,7 @@ namespace Rules.Framework.Tests
                 RootCondition = new StringConditionNode<ConditionType>(ConditionType.IsoCountryCode, Operators.Equal, "USA")
             };
 
-            Rule<ContentType, ConditionType> rule2 = new Rule<ContentType, ConditionType>
+            var rule2 = new Rule<ContentType, ConditionType>
             {
                 ContentContainer = new ContentContainer<ContentType>(contentType, (t) => new object()),
                 DateBegin = new DateTime(2020, 01, 01),
@@ -40,7 +40,7 @@ namespace Rules.Framework.Tests
                 RootCondition = new StringConditionNode<ConditionType>(ConditionType.IsoCountryCode, Operators.Equal, "USA")
             };
 
-            Rule<ContentType, ConditionType> rule3 = new Rule<ContentType, ConditionType>
+            var rule3 = new Rule<ContentType, ConditionType>
             {
                 ContentContainer = new ContentContainer<ContentType>(contentType, (t) => new object()),
                 DateBegin = dateBegin,
@@ -50,18 +50,57 @@ namespace Rules.Framework.Tests
                 RootCondition = new StringConditionNode<ConditionType>(ConditionType.IsoCurrency, Operators.Equal, "EUR")
             };
 
+            var rule4 = new Rule<ContentType, ConditionType>
+            {
+                ContentContainer = new ContentContainer<ContentType>(contentType, (t) => new object()),
+                DateBegin = dateBegin,
+                DateEnd = dateEnd,
+                Name = "Rule 4",
+                Priority = 1,
+                RootCondition = new ComposedConditionNode<ConditionType>(
+                LogicalOperators.And,
+                new IConditionNode<ConditionType>[]
+                {
+                    new StringConditionNode<ConditionType>(ConditionType.IsVip, Operators.Equal, "true"),
+                    new StringConditionNode<ConditionType>(ConditionType.PluviosityRate, Operators.Equal, "15"),
+                    new StringConditionNode<ConditionType>(ConditionType.IsoCurrency, Operators.Equal, "JPY")
+                }
+                )
+            };
+
             var matchRules = new[]
             {
                 rule1,
                 rule2,
-                rule3
+                rule3,
+                rule4
             };
 
             var expectedConditionTypeList = new List<ConditionType>()
             {
                 ConditionType.IsoCurrency,
-                ConditionType.IsoCountryCode
+                ConditionType.IsoCountryCode,
+                ConditionType.IsVip,
+                ConditionType.PluviosityRate
             };
+
+            var conditionTypeExtractor = new ConditionTypeExtractor<ContentType, ConditionType>();
+
+            // Act
+            var actual = conditionTypeExtractor.GetConditionTypes(matchRules);
+
+            // Assert
+            actual.Should().BeEquivalentTo(expectedConditionTypeList);
+        }
+
+        [Fact]
+        public void GetConditionTypes_WithEmptyMatchRules_ReturnsEmptyListConditionTypes()
+        {
+            // Arrange
+
+            var matchRules = new List<Rule<ContentType, ConditionType>>();
+
+            var expectedConditionTypeList = new List<ConditionType>();
 
             var conditionTypeExtractor = new ConditionTypeExtractor<ContentType, ConditionType>();
 

--- a/tests/Rules.Framework.Tests/ConditionTypeExtractorTests.cs
+++ b/tests/Rules.Framework.Tests/ConditionTypeExtractorTests.cs
@@ -121,7 +121,7 @@ namespace Rules.Framework.Tests
 
             var contentType = ContentType.Type1;
 
-            var matchRules = new List<Rule<ContentType, ConditionType>>()
+            var matchRules = new List<Rule<ContentType, ConditionType>>
             {
                    new Rule<ContentType, ConditionType>
             {

--- a/tests/Rules.Framework.Tests/ConditionTypeExtractorTests.cs
+++ b/tests/Rules.Framework.Tests/ConditionTypeExtractorTests.cs
@@ -1,0 +1,75 @@
+namespace Rules.Framework.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using FluentAssertions;
+    using Rules.Framework.Core;
+    using Rules.Framework.Core.ConditionNodes;
+    using Rules.Framework.Tests.TestStubs;
+    using Xunit;
+
+    public class ConditionTypeExtractorTests
+    {
+        [Fact]
+        public void GetConditionTypes_ReturnsCorrectExtraction()
+        {
+            // Arrange
+
+            DateTime dateBegin = new DateTime(2018, 01, 01);
+            DateTime dateEnd = new DateTime(2019, 01, 01);
+
+            ContentType contentType = ContentType.Type1;
+
+            Rule<ContentType, ConditionType> rule1 = new Rule<ContentType, ConditionType>
+            {
+                ContentContainer = new ContentContainer<ContentType>(contentType, (t) => new object()),
+                DateBegin = dateBegin,
+                DateEnd = dateEnd,
+                Name = "Rule 1",
+                Priority = 3,
+                RootCondition = new StringConditionNode<ConditionType>(ConditionType.IsoCountryCode, Operators.Equal, "USA")
+            };
+
+            Rule<ContentType, ConditionType> rule2 = new Rule<ContentType, ConditionType>
+            {
+                ContentContainer = new ContentContainer<ContentType>(contentType, (t) => new object()),
+                DateBegin = new DateTime(2020, 01, 01),
+                DateEnd = new DateTime(2021, 01, 01),
+                Name = "Rule 2",
+                Priority = 200,
+                RootCondition = new StringConditionNode<ConditionType>(ConditionType.IsoCountryCode, Operators.Equal, "USA")
+            };
+
+            Rule<ContentType, ConditionType> rule3 = new Rule<ContentType, ConditionType>
+            {
+                ContentContainer = new ContentContainer<ContentType>(contentType, (t) => new object()),
+                DateBegin = dateBegin,
+                DateEnd = dateEnd,
+                Name = "Rule 3",
+                Priority = 1,
+                RootCondition = new StringConditionNode<ConditionType>(ConditionType.IsoCurrency, Operators.Equal, "EUR")
+            };
+
+            var matchRules = new[]
+            {
+                rule1,
+                rule2,
+                rule3
+            };
+
+            var expectedConditionTypeList = new List<ConditionType>()
+            {
+                ConditionType.IsoCurrency,
+                ConditionType.IsoCountryCode
+            };
+
+            var conditionTypeExtractor = new ConditionTypeExtractor<ContentType, ConditionType>();
+
+            // Act
+            var actual = conditionTypeExtractor.GetConditionTypes(matchRules);
+
+            // Assert
+            actual.Should().BeEquivalentTo(expectedConditionTypeList);
+        }
+    }
+}

--- a/tests/Rules.Framework.Tests/ConditionTypeExtractorTests.cs
+++ b/tests/Rules.Framework.Tests/ConditionTypeExtractorTests.cs
@@ -110,5 +110,39 @@ namespace Rules.Framework.Tests
             // Assert
             actual.Should().BeEquivalentTo(expectedConditionTypeList);
         }
+
+        [Fact]
+        public void GetConditionTypes_WithNullRootCondition_ReturnsEmptyListConditionTypes()
+        {
+            // Arrange
+
+            var dateBegin = new DateTime(2018, 01, 01);
+            var dateEnd = new DateTime(2019, 01, 01);
+
+            var contentType = ContentType.Type1;
+
+            var matchRules = new List<Rule<ContentType, ConditionType>>()
+            {
+                   new Rule<ContentType, ConditionType>
+            {
+                ContentContainer = new ContentContainer<ContentType>(contentType, _ => new object()),
+                DateBegin = dateBegin,
+                DateEnd = dateEnd,
+                Name = "Rule 3",
+                Priority = 1,
+                RootCondition = null
+            }
+            };
+
+            var expectedConditionTypeList = new List<ConditionType>();
+
+            var conditionTypeExtractor = new ConditionTypeExtractor<ContentType, ConditionType>();
+
+            // Act
+            var actual = conditionTypeExtractor.GetConditionTypes(matchRules);
+
+            // Assert
+            actual.Should().BeEquivalentTo(expectedConditionTypeList);
+        }
     }
 }

--- a/tests/Rules.Framework.Tests/Rules.Framework.Tests.csproj
+++ b/tests/Rules.Framework.Tests/Rules.Framework.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>9.0</LangVersion>
     <DebugType>Full</DebugType>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/tests/Rules.Framework.Tests/RulesEngineTests.cs
+++ b/tests/Rules.Framework.Tests/RulesEngineTests.cs
@@ -90,7 +90,7 @@ namespace Rules.Framework.Tests
             mockCondtionTypeExtractor.Setup(x => x.GetConditionTypes(It.IsAny<IEnumerable<Rule<ContentType, ConditionType>>>()))
                 .Returns(expectedCondtionTypes);
 
-            this.SetupMockForConditionsEvalEngine((rootConditionNode, _, __) =>
+            this.SetupMockForConditionsEvalEngine((rootConditionNode, _, _) =>
             {
                 switch (rootConditionNode)
                 {
@@ -180,7 +180,7 @@ namespace Rules.Framework.Tests
             };
             this.SetupMockForRulesDataSource(rules);
 
-            this.SetupMockForConditionsEvalEngine((rootConditionNode, _, __) =>
+            this.SetupMockForConditionsEvalEngine((rootConditionNode, _, _) =>
             {
                 switch (rootConditionNode)
                 {

--- a/tests/Rules.Framework.Tests/RulesEngineTests.cs
+++ b/tests/Rules.Framework.Tests/RulesEngineTests.cs
@@ -30,7 +30,7 @@ namespace Rules.Framework.Tests
                 DateEnd = new DateTime(2019, 01, 01),
                 Name = "Test rule",
                 Priority = 3,
-                RootCondition = new StringConditionNode<ConditionType>(ConditionType.IsoCountryCode, Operators.Equal, "USA")
+                RootCondition = new ValueConditionNode<ConditionType>(DataTypes.String, ConditionType.IsoCountryCode, Operators.Equal, "USA")
             };
 
             EvaluationOptions evaluationOptions = new EvaluationOptions
@@ -78,17 +78,7 @@ namespace Rules.Framework.Tests
                 DateEnd = dateEnd,
                 Name = "Rule 1",
                 Priority = 3,
-                RootCondition = new StringConditionNode<ConditionType>(ConditionType.IsoCountryCode, Operators.Equal, "USA")
-            };
-
-            Rule<ContentType, ConditionType> rule2 = new Rule<ContentType, ConditionType>
-            {
-                ContentContainer = new ContentContainer<ContentType>(contentType, (t) => new object()),
-                DateBegin = new DateTime(2020, 01, 01),
-                DateEnd = new DateTime(2021, 01, 01),
-                Name = "Rule 2",
-                Priority = 200,
-                RootCondition = new StringConditionNode<ConditionType>(ConditionType.IsoCountryCode, Operators.Equal, "USA")
+                RootCondition = new ValueConditionNode<ConditionType>(DataTypes.String, ConditionType.IsoCountryCode, Operators.Equal, "USA")
             };
 
             Rule<ContentType, ConditionType> rule3 = new Rule<ContentType, ConditionType>
@@ -98,7 +88,7 @@ namespace Rules.Framework.Tests
                 DateEnd = dateEnd,
                 Name = "Rule 3",
                 Priority = 1,
-                RootCondition = new StringConditionNode<ConditionType>(ConditionType.IsoCountryCode, Operators.Equal, "CHE")
+                RootCondition = new ValueConditionNode<ConditionType>(DataTypes.String, ConditionType.IsoCountryCode, Operators.Equal, "CHE")
             };
 
             IEnumerable<Rule<ContentType, ConditionType>> rules = new[]
@@ -124,8 +114,8 @@ namespace Rules.Framework.Tests
             {
                 switch (rootConditionNode)
                 {
-                    case StringConditionNode<ConditionType> stringConditionNode:
-                        return stringConditionNode.Operand == "USA";
+                    case ValueConditionNode<ConditionType> stringConditionNode:
+                        return stringConditionNode.Operand.ToString() == "USA";
 
                     default:
                         return false;
@@ -174,7 +164,7 @@ namespace Rules.Framework.Tests
                 DateEnd = new DateTime(2019, 01, 01),
                 Name = "Expected rule 1",
                 Priority = 3,
-                RootCondition = new StringConditionNode<ConditionType>(ConditionType.IsoCountryCode, Operators.Equal, "USA")
+                RootCondition = new ValueConditionNode<ConditionType>(DataTypes.String, ConditionType.IsoCountryCode, Operators.Equal, "USA")
             };
 
             Rule<ContentType, ConditionType> expected2 = new Rule<ContentType, ConditionType>
@@ -184,7 +174,7 @@ namespace Rules.Framework.Tests
                 DateEnd = new DateTime(2021, 01, 01),
                 Name = "Expected rule 2",
                 Priority = 200,
-                RootCondition = new StringConditionNode<ConditionType>(ConditionType.IsoCountryCode, Operators.Equal, "USA")
+                RootCondition = new ValueConditionNode<ConditionType>(DataTypes.String, ConditionType.IsoCountryCode, Operators.Equal, "USA")
             };
 
             Rule<ContentType, ConditionType> notExpected = new Rule<ContentType, ConditionType>
@@ -194,7 +184,7 @@ namespace Rules.Framework.Tests
                 DateEnd = new DateTime(2019, 01, 01),
                 Name = "Not expected rule",
                 Priority = 1, // Topmost rule, should be the one that wins if options are set to topmost wins.
-                RootCondition = new StringConditionNode<ConditionType>(ConditionType.IsoCountryCode, Operators.Equal, "CHE")
+                RootCondition = new ValueConditionNode<ConditionType>(DataTypes.String, ConditionType.IsoCountryCode, Operators.Equal, "CHE")
             };
 
             IEnumerable<Rule<ContentType, ConditionType>> rules = new[]
@@ -213,8 +203,8 @@ namespace Rules.Framework.Tests
             {
                 switch (rootConditionNode)
                 {
-                    case StringConditionNode<ConditionType> stringConditionNode:
-                        return stringConditionNode.Operand == "USA";
+                    case ValueConditionNode<ConditionType> stringConditionNode:
+                        return stringConditionNode.Operand.ToString() == "USA";
 
                     default:
                         return false;
@@ -269,7 +259,7 @@ namespace Rules.Framework.Tests
                 DateEnd = new DateTime(2019, 01, 01),
                 Name = "Expected rule",
                 Priority = 3,
-                RootCondition = new StringConditionNode<ConditionType>(ConditionType.IsoCountryCode, Operators.Equal, "USA")
+                RootCondition = new ValueConditionNode<ConditionType>(DataTypes.String, ConditionType.IsoCountryCode, Operators.Equal, "USA")
             };
 
             Rule<ContentType, ConditionType> expected = new Rule<ContentType, ConditionType>
@@ -279,7 +269,7 @@ namespace Rules.Framework.Tests
                 DateEnd = new DateTime(2021, 01, 01),
                 Name = "Expected rule",
                 Priority = 200,
-                RootCondition = new StringConditionNode<ConditionType>(ConditionType.IsoCountryCode, Operators.Equal, "USA")
+                RootCondition = new ValueConditionNode<ConditionType>(DataTypes.String, ConditionType.IsoCountryCode, Operators.Equal, "USA")
             };
 
             IEnumerable<Rule<ContentType, ConditionType>> rules = new[]
@@ -341,7 +331,7 @@ namespace Rules.Framework.Tests
                 DateEnd = new DateTime(2019, 01, 01),
                 Name = "Expected rule",
                 Priority = 3,
-                RootCondition = new StringConditionNode<ConditionType>(ConditionType.IsoCountryCode, Operators.Equal, "USA")
+                RootCondition = new ValueConditionNode<ConditionType>(DataTypes.String, ConditionType.IsoCountryCode, Operators.Equal, "USA")
             };
 
             Rule<ContentType, ConditionType> other = new Rule<ContentType, ConditionType>
@@ -351,7 +341,7 @@ namespace Rules.Framework.Tests
                 DateEnd = new DateTime(2021, 01, 01),
                 Name = "Expected rule",
                 Priority = 200,
-                RootCondition = new StringConditionNode<ConditionType>(ConditionType.IsoCountryCode, Operators.Equal, "USA")
+                RootCondition = new ValueConditionNode<ConditionType>(DataTypes.String, ConditionType.IsoCountryCode, Operators.Equal, "USA")
             };
 
             IEnumerable<Rule<ContentType, ConditionType>> rules = new[]
@@ -414,7 +404,7 @@ namespace Rules.Framework.Tests
                     DateEnd = new DateTime(2019, 01, 01),
                     Name = "Expected rule",
                     Priority = 3,
-                    RootCondition = new StringConditionNode<ConditionType>(ConditionType.IsoCountryCode, Operators.Equal, "USA")
+                    RootCondition = new ValueConditionNode<ConditionType>(DataTypes.String,ConditionType.IsoCountryCode, Operators.Equal, "USA")
                 },
                 new Rule<ContentType, ConditionType>
                 {
@@ -423,7 +413,7 @@ namespace Rules.Framework.Tests
                     DateEnd = new DateTime(2021, 01, 01),
                     Name = "Expected rule",
                     Priority = 200,
-                    RootCondition = new StringConditionNode<ConditionType>(ConditionType.IsoCountryCode, Operators.Equal, "USA")
+                    RootCondition = new ValueConditionNode<ConditionType>(DataTypes.String,ConditionType.IsoCountryCode, Operators.Equal, "USA")
                 }
             };
 
@@ -470,7 +460,7 @@ namespace Rules.Framework.Tests
                     DateEnd = new DateTime(2019, 01, 01),
                     Name = "Expected rule",
                     Priority = 3,
-                    RootCondition = new StringConditionNode<ConditionType>(ConditionType.IsoCountryCode, Operators.Equal, "USA")
+                    RootCondition = new ValueConditionNode<ConditionType>(DataTypes.String,ConditionType.IsoCountryCode, Operators.Equal, "USA")
                 },
                 new Rule<ContentType, ConditionType>
                 {
@@ -479,7 +469,7 @@ namespace Rules.Framework.Tests
                     DateEnd = new DateTime(2021, 01, 01),
                     Name = "Expected rule",
                     Priority = 200,
-                    RootCondition = new StringConditionNode<ConditionType>(ConditionType.IsoCountryCode, Operators.Equal, "USA")
+                    RootCondition = new ValueConditionNode<ConditionType>(DataTypes.String,ConditionType.IsoCountryCode, Operators.Equal, "USA")
                 }
             };
 
@@ -531,7 +521,7 @@ namespace Rules.Framework.Tests
                     DateEnd = new DateTime(2019, 01, 01),
                     Name = "Expected rule",
                     Priority = 3,
-                    RootCondition = new StringConditionNode<ConditionType>(ConditionType.IsoCountryCode, Operators.Equal, "USA")
+                    RootCondition = new ValueConditionNode<ConditionType>(DataTypes.String,ConditionType.IsoCountryCode, Operators.Equal, "USA")
                 },
                 new Rule<ContentType, ConditionType>
                 {
@@ -540,7 +530,7 @@ namespace Rules.Framework.Tests
                     DateEnd = new DateTime(2021, 01, 01),
                     Name = "Expected rule",
                     Priority = 200,
-                    RootCondition = new StringConditionNode<ConditionType>(ConditionType.IsoCountryCode, Operators.Equal, "USA")
+                    RootCondition = new ValueConditionNode<ConditionType>(DataTypes.String,ConditionType.IsoCountryCode, Operators.Equal, "USA")
                 }
             };
 

--- a/tests/Rules.Framework.Tests/RulesEngineTests.cs
+++ b/tests/Rules.Framework.Tests/RulesEngineTests.cs
@@ -80,28 +80,6 @@ namespace Rules.Framework.Tests
             DateTime dateBegin = new DateTime(2018, 01, 01);
             DateTime dateEnd = new DateTime(2019, 01, 01);
 
-            ContentType contentType = ContentType.Type1;
-
-            Rule<ContentType, ConditionType> rule1 = new Rule<ContentType, ConditionType>
-            {
-                ContentContainer = new ContentContainer<ContentType>(contentType, (t) => new object()),
-                DateBegin = dateBegin,
-                DateEnd = dateEnd,
-                Name = "Rule 1",
-                Priority = 3,
-                RootCondition = new ValueConditionNode<ConditionType>(DataTypes.String, ConditionType.IsoCountryCode, Operators.Equal, "USA")
-            };
-
-            Rule<ContentType, ConditionType> rule3 = new Rule<ContentType, ConditionType>
-            {
-                ContentContainer = new ContentContainer<ContentType>(contentType, (t) => new object()),
-                DateBegin = dateBegin,
-                DateEnd = dateEnd,
-                Name = "Rule 3",
-                Priority = 1,
-                RootCondition = new ValueConditionNode<ConditionType>(DataTypes.String, ConditionType.IsoCountryCode, Operators.Equal, "CHE")
-            };
-
             EvaluationOptions evaluationOptions = new EvaluationOptions
             {
                 MatchMode = MatchModes.Exact
@@ -112,7 +90,7 @@ namespace Rules.Framework.Tests
             mockCondtionTypeExtractor.Setup(x => x.GetConditionTypes(It.IsAny<IEnumerable<Rule<ContentType, ConditionType>>>()))
                 .Returns(expectedCondtionTypes);
 
-            this.SetupMockForConditionsEvalEngine((rootConditionNode, _, evalOptions) =>
+            this.SetupMockForConditionsEvalEngine((rootConditionNode, _, __) =>
             {
                 switch (rootConditionNode)
                 {
@@ -202,7 +180,7 @@ namespace Rules.Framework.Tests
             };
             this.SetupMockForRulesDataSource(rules);
 
-            this.SetupMockForConditionsEvalEngine((rootConditionNode, inputConditions, evalOptions) =>
+            this.SetupMockForConditionsEvalEngine((rootConditionNode, _, __) =>
             {
                 switch (rootConditionNode)
                 {

--- a/tests/Rules.Framework.Tests/RulesEngineTests.cs
+++ b/tests/Rules.Framework.Tests/RulesEngineTests.cs
@@ -17,6 +17,17 @@ namespace Rules.Framework.Tests
 
     public class RulesEngineTests
     {
+        private readonly Mock<IConditionsEvalEngine<ConditionType>> mockConditionsEvalEngine;
+        private readonly Mock<IConditionTypeExtractor<ContentType, ConditionType>> mockCondtionTypeExtractor;
+        private readonly Mock<IRulesDataSource<ContentType, ConditionType>> mockRulesDataSource;
+
+        public RulesEngineTests()
+        {
+            this.mockRulesDataSource = new Mock<IRulesDataSource<ContentType, ConditionType>>();
+            this.mockCondtionTypeExtractor = new Mock<IConditionTypeExtractor<ContentType, ConditionType>>();
+            this.mockConditionsEvalEngine = new Mock<IConditionsEvalEngine<ConditionType>>();
+        }
+
         [Fact]
         public async Task AddRuleAsync_GivenEmptyRuleDataSource_AddsRuleSuccesfully()
         {
@@ -37,9 +48,9 @@ namespace Rules.Framework.Tests
             {
                 MatchMode = MatchModes.Exact
             };
-            Mock<IRulesDataSource<ContentType, ConditionType>> mockRulesDataSource = new Mock<IRulesDataSource<ContentType, ConditionType>>();
-            Mock<IConditionsEvalEngine<ConditionType>> mockConditionsEvalEngine = SetupMockForConditionsEvalEngine(true, evaluationOptions);
-            Mock<IConditionTypeExtractor<ContentType, ConditionType>> mockCondtionTypeExtractor = new Mock<IConditionTypeExtractor<ContentType, ConditionType>>();
+
+            this.SetupMockForConditionsEvalEngine(true, evaluationOptions);
+
             IValidatorProvider validatorProvider = Mock.Of<IValidatorProvider>();
             RulesEngineOptions rulesEngineOptions = RulesEngineOptions.NewWithDefaults();
 
@@ -104,13 +115,10 @@ namespace Rules.Framework.Tests
 
             var expectedCondtionTypes = new List<ConditionType>() { ConditionType.IsoCountryCode };
 
-            Mock<IConditionTypeExtractor<ContentType, ConditionType>> mockCondtionTypeExtractor = new Mock<IConditionTypeExtractor<ContentType, ConditionType>>();
             mockCondtionTypeExtractor.Setup(x => x.GetConditionTypes(It.IsAny<IEnumerable<Rule<ContentType, ConditionType>>>()))
                 .Returns(expectedCondtionTypes);
 
-            Mock<IRulesDataSource<ContentType, ConditionType>> mockRulesDataSource = SetupMockForRulesDataSource(rules);
-
-            Mock<IConditionsEvalEngine<ConditionType>> mockConditionsEvalEngine = SetupMockForConditionsEvalEngine((rootConditionNode, inputConditions, evalOptions) =>
+            this.SetupMockForConditionsEvalEngine((rootConditionNode, inputConditions, evalOptions) =>
             {
                 switch (rootConditionNode)
                 {
@@ -198,8 +206,9 @@ namespace Rules.Framework.Tests
             {
                 MatchMode = MatchModes.Exact
             };
-            Mock<IRulesDataSource<ContentType, ConditionType>> mockRulesDataSource = SetupMockForRulesDataSource(rules);
-            Mock<IConditionsEvalEngine<ConditionType>> mockConditionsEvalEngine = SetupMockForConditionsEvalEngine((rootConditionNode, inputConditions, evalOptions) =>
+            this.SetupMockForRulesDataSource(rules);
+
+            this.SetupMockForConditionsEvalEngine((rootConditionNode, inputConditions, evalOptions) =>
             {
                 switch (rootConditionNode)
                 {
@@ -210,9 +219,8 @@ namespace Rules.Framework.Tests
                         return false;
                 }
             }, evaluationOptions);
-            IValidatorProvider validatorProvider = Mock.Of<IValidatorProvider>();
 
-            Mock<IConditionTypeExtractor<ContentType, ConditionType>> mockCondtionTypeExtractor = new Mock<IConditionTypeExtractor<ContentType, ConditionType>>();
+            IValidatorProvider validatorProvider = Mock.Of<IValidatorProvider>();
 
             RulesEngineOptions rulesEngineOptions = RulesEngineOptions.NewWithDefaults();
 
@@ -282,9 +290,11 @@ namespace Rules.Framework.Tests
             {
                 MatchMode = MatchModes.Exact
             };
-            Mock<IRulesDataSource<ContentType, ConditionType>> mockRulesDataSource = SetupMockForRulesDataSource(rules);
-            Mock<IConditionsEvalEngine<ConditionType>> mockConditionsEvalEngine = SetupMockForConditionsEvalEngine(true, evaluationOptions);
-            Mock<IConditionTypeExtractor<ContentType, ConditionType>> mockCondtionTypeExtractor = new Mock<IConditionTypeExtractor<ContentType, ConditionType>>();
+
+            this.SetupMockForRulesDataSource(rules);
+
+            this.SetupMockForConditionsEvalEngine(true, evaluationOptions);
+
             IValidatorProvider validatorProvider = Mock.Of<IValidatorProvider>();
             RulesEngineOptions rulesEngineOptions = RulesEngineOptions.NewWithDefaults();
 
@@ -354,10 +364,11 @@ namespace Rules.Framework.Tests
             {
                 MatchMode = MatchModes.Exact
             };
-            Mock<IRulesDataSource<ContentType, ConditionType>> mockRulesDataSource = SetupMockForRulesDataSource(rules);
-            Mock<IConditionsEvalEngine<ConditionType>> mockConditionsEvalEngine = SetupMockForConditionsEvalEngine(true, evaluationOptions);
 
-            Mock<IConditionTypeExtractor<ContentType, ConditionType>> mockCondtionTypeExtractor = new Mock<IConditionTypeExtractor<ContentType, ConditionType>>();
+            this.SetupMockForRulesDataSource(rules);
+
+            this.SetupMockForConditionsEvalEngine(true, evaluationOptions);
+
             IValidatorProvider validatorProvider = Mock.Of<IValidatorProvider>();
             RulesEngineOptions rulesEngineOptions = RulesEngineOptions.NewWithDefaults();
 
@@ -421,10 +432,10 @@ namespace Rules.Framework.Tests
             {
                 MatchMode = MatchModes.Exact
             };
-            Mock<IRulesDataSource<ContentType, ConditionType>> mockRulesDataSource = SetupMockForRulesDataSource(rules);
-            Mock<IConditionsEvalEngine<ConditionType>> mockConditionsEvalEngine = SetupMockForConditionsEvalEngine(false, evaluationOptions);
 
-            Mock<IConditionTypeExtractor<ContentType, ConditionType>> mockCondtionTypeExtractor = new Mock<IConditionTypeExtractor<ContentType, ConditionType>>();
+            this.SetupMockForRulesDataSource(rules);
+
+            this.SetupMockForConditionsEvalEngine(false, evaluationOptions);
 
             IValidatorProvider validatorProvider = Mock.Of<IValidatorProvider>();
             RulesEngineOptions rulesEngineOptions = RulesEngineOptions.NewWithDefaults();
@@ -478,10 +489,9 @@ namespace Rules.Framework.Tests
                 MatchMode = MatchModes.Exact
             };
 
-            Mock<IConditionTypeExtractor<ContentType, ConditionType>> mockCondtionTypeExtractor = new Mock<IConditionTypeExtractor<ContentType, ConditionType>>();
+            this.SetupMockForRulesDataSource(rules);
 
-            Mock<IRulesDataSource<ContentType, ConditionType>> mockRulesDataSource = SetupMockForRulesDataSource(rules);
-            Mock<IConditionsEvalEngine<ConditionType>> mockConditionsEvalEngine = SetupMockForConditionsEvalEngine(false, evaluationOptions);
+            this.SetupMockForConditionsEvalEngine(false, evaluationOptions);
 
             IValidator<SearchArgs<ContentType, ConditionType>> validator = Mock.Of<IValidator<SearchArgs<ContentType, ConditionType>>>();
             Mock.Get(validator)
@@ -539,10 +549,9 @@ namespace Rules.Framework.Tests
                 MatchMode = MatchModes.Exact
             };
 
-            Mock<IConditionTypeExtractor<ContentType, ConditionType>> mockCondtionTypeExtractor = new Mock<IConditionTypeExtractor<ContentType, ConditionType>>();
+            this.SetupMockForRulesDataSource(rules);
 
-            Mock<IRulesDataSource<ContentType, ConditionType>> mockRulesDataSource = SetupMockForRulesDataSource(rules);
-            Mock<IConditionsEvalEngine<ConditionType>> mockConditionsEvalEngine = SetupMockForConditionsEvalEngine(false, evaluationOptions);
+            this.SetupMockForConditionsEvalEngine(false, evaluationOptions);
             IValidatorProvider validatorProvider = Mock.Of<IValidatorProvider>();
             RulesEngineOptions rulesEngineOptions = RulesEngineOptions.NewWithDefaults();
 
@@ -556,34 +565,28 @@ namespace Rules.Framework.Tests
             argumentNullException.ParamName.Should().Be(nameof(searchArgs));
         }
 
-        private static Mock<IConditionsEvalEngine<ConditionType>> SetupMockForConditionsEvalEngine(bool result, EvaluationOptions evaluationOptions)
+        private void SetupMockForConditionsEvalEngine(Func<IConditionNode<ConditionType>, IEnumerable<Condition<ConditionType>>, EvaluationOptions, bool> evalFunc, EvaluationOptions evaluationOptions)
         {
-            Mock<IConditionsEvalEngine<ConditionType>> mockConditionsEvalEngine = new Mock<IConditionsEvalEngine<ConditionType>>();
-            mockConditionsEvalEngine.Setup(x => x.Eval(
-                    It.IsAny<IConditionNode<ConditionType>>(),
-                    It.IsAny<IEnumerable<Condition<ConditionType>>>(),
-                    It.Is<EvaluationOptions>(eo => eo == evaluationOptions)))
-                .Returns(result);
-            return mockConditionsEvalEngine;
-        }
-
-        private static Mock<IConditionsEvalEngine<ConditionType>> SetupMockForConditionsEvalEngine(Func<IConditionNode<ConditionType>, IEnumerable<Condition<ConditionType>>, EvaluationOptions, bool> evalFunc, EvaluationOptions evaluationOptions)
-        {
-            Mock<IConditionsEvalEngine<ConditionType>> mockConditionsEvalEngine = new Mock<IConditionsEvalEngine<ConditionType>>();
-            mockConditionsEvalEngine.Setup(x => x.Eval(
+            this.mockConditionsEvalEngine.Setup(x => x.Eval(
                     It.IsAny<IConditionNode<ConditionType>>(),
                     It.IsAny<IEnumerable<Condition<ConditionType>>>(),
                     It.Is<EvaluationOptions>(eo => eo == evaluationOptions)))
                 .Returns(evalFunc);
-            return mockConditionsEvalEngine;
         }
 
-        private static Mock<IRulesDataSource<ContentType, ConditionType>> SetupMockForRulesDataSource(IEnumerable<Rule<ContentType, ConditionType>> rules)
+        private void SetupMockForConditionsEvalEngine(bool result, EvaluationOptions evaluationOptions)
         {
-            Mock<IRulesDataSource<ContentType, ConditionType>> mockRulesDataSource = new Mock<IRulesDataSource<ContentType, ConditionType>>();
-            mockRulesDataSource.Setup(x => x.GetRulesAsync(It.IsAny<ContentType>(), It.IsAny<DateTime>(), It.IsAny<DateTime>()))
+            this.mockConditionsEvalEngine.Setup(x => x.Eval(
+                    It.IsAny<IConditionNode<ConditionType>>(),
+                    It.IsAny<IEnumerable<Condition<ConditionType>>>(),
+                    It.Is<EvaluationOptions>(eo => eo == evaluationOptions)))
+                .Returns(result);
+        }
+
+        private void SetupMockForRulesDataSource(IEnumerable<Rule<ContentType, ConditionType>> rules)
+        {
+            this.mockRulesDataSource.Setup(x => x.GetRulesAsync(It.IsAny<ContentType>(), It.IsAny<DateTime>(), It.IsAny<DateTime>()))
                 .ReturnsAsync(rules);
-            return mockRulesDataSource;
         }
     }
 }

--- a/tests/Rules.Framework.Tests/RulesEngineTests.cs
+++ b/tests/Rules.Framework.Tests/RulesEngineTests.cs
@@ -39,12 +39,13 @@ namespace Rules.Framework.Tests
             };
             Mock<IRulesDataSource<ContentType, ConditionType>> mockRulesDataSource = new Mock<IRulesDataSource<ContentType, ConditionType>>();
             Mock<IConditionsEvalEngine<ConditionType>> mockConditionsEvalEngine = SetupMockForConditionsEvalEngine(true, evaluationOptions);
+            Mock<IConditionTypeExtractor<ContentType, ConditionType>> mockCondtionTypeExtractor = new Mock<IConditionTypeExtractor<ContentType, ConditionType>>();
             IValidatorProvider validatorProvider = Mock.Of<IValidatorProvider>();
             RulesEngineOptions rulesEngineOptions = RulesEngineOptions.NewWithDefaults();
 
             rulesEngineOptions.PriotityCriteria = PriorityCriterias.BottommostRuleWins;
 
-            RulesEngine<ContentType, ConditionType> sut = new RulesEngine<ContentType, ConditionType>(mockConditionsEvalEngine.Object, mockRulesDataSource.Object, validatorProvider, rulesEngineOptions);
+            RulesEngine<ContentType, ConditionType> sut = new RulesEngine<ContentType, ConditionType>(mockConditionsEvalEngine.Object, mockRulesDataSource.Object, validatorProvider, rulesEngineOptions, mockCondtionTypeExtractor.Object);
 
             // Act
             var actual = await sut.AddRuleAsync(testRule, RuleAddPriorityOption.AtBottom);
@@ -111,6 +112,12 @@ namespace Rules.Framework.Tests
                 MatchMode = MatchModes.Exact
             };
 
+            var expectedCondtionTypes = new List<ConditionType>() { ConditionType.IsoCountryCode };
+
+            Mock<IConditionTypeExtractor<ContentType, ConditionType>> mockCondtionTypeExtractor = new Mock<IConditionTypeExtractor<ContentType, ConditionType>>();
+            mockCondtionTypeExtractor.Setup(x => x.GetConditionTypes(It.IsAny<IEnumerable<Rule<ContentType, ConditionType>>>()))
+                .Returns(expectedCondtionTypes);
+
             Mock<IRulesDataSource<ContentType, ConditionType>> mockRulesDataSource = SetupMockForRulesDataSource(rules);
 
             Mock<IConditionsEvalEngine<ConditionType>> mockConditionsEvalEngine = SetupMockForConditionsEvalEngine((rootConditionNode, inputConditions, evalOptions) =>
@@ -129,14 +136,15 @@ namespace Rules.Framework.Tests
 
             RulesEngineOptions rulesEngineOptions = RulesEngineOptions.NewWithDefaults();
 
-            RulesEngine<ContentType, ConditionType> sut = new RulesEngine<ContentType, ConditionType>(mockConditionsEvalEngine.Object, mockRulesDataSource.Object, validatorProvider, rulesEngineOptions);
+            RulesEngine<ContentType, ConditionType> sut = new RulesEngine<ContentType, ConditionType>(mockConditionsEvalEngine.Object, mockRulesDataSource.Object, validatorProvider, rulesEngineOptions, mockCondtionTypeExtractor.Object);
 
             // Act
             var actual = await sut.GetUniqueConditionTypesAsync(ContentType.Type1, dateBegin, dateEnd);
 
             // Assert
             actual.Should().NotBeNull();
-            actual.ToList().Count.Should().Be(2);
+            actual.ToList().Count.Should().Be(1);
+            actual.Should().BeEquivalentTo(expectedCondtionTypes);
         }
 
         [Fact]
@@ -213,9 +221,12 @@ namespace Rules.Framework.Tests
                 }
             }, evaluationOptions);
             IValidatorProvider validatorProvider = Mock.Of<IValidatorProvider>();
+
+            Mock<IConditionTypeExtractor<ContentType, ConditionType>> mockCondtionTypeExtractor = new Mock<IConditionTypeExtractor<ContentType, ConditionType>>();
+
             RulesEngineOptions rulesEngineOptions = RulesEngineOptions.NewWithDefaults();
 
-            RulesEngine<ContentType, ConditionType> sut = new RulesEngine<ContentType, ConditionType>(mockConditionsEvalEngine.Object, mockRulesDataSource.Object, validatorProvider, rulesEngineOptions);
+            RulesEngine<ContentType, ConditionType> sut = new RulesEngine<ContentType, ConditionType>(mockConditionsEvalEngine.Object, mockRulesDataSource.Object, validatorProvider, rulesEngineOptions, mockCondtionTypeExtractor.Object);
 
             // Act
             IEnumerable<Rule<ContentType, ConditionType>> actual = await sut.MatchManyAsync(contentType, matchDateTime, conditions);
@@ -283,12 +294,13 @@ namespace Rules.Framework.Tests
             };
             Mock<IRulesDataSource<ContentType, ConditionType>> mockRulesDataSource = SetupMockForRulesDataSource(rules);
             Mock<IConditionsEvalEngine<ConditionType>> mockConditionsEvalEngine = SetupMockForConditionsEvalEngine(true, evaluationOptions);
+            Mock<IConditionTypeExtractor<ContentType, ConditionType>> mockCondtionTypeExtractor = new Mock<IConditionTypeExtractor<ContentType, ConditionType>>();
             IValidatorProvider validatorProvider = Mock.Of<IValidatorProvider>();
             RulesEngineOptions rulesEngineOptions = RulesEngineOptions.NewWithDefaults();
 
             rulesEngineOptions.PriotityCriteria = PriorityCriterias.BottommostRuleWins;
 
-            RulesEngine<ContentType, ConditionType> sut = new RulesEngine<ContentType, ConditionType>(mockConditionsEvalEngine.Object, mockRulesDataSource.Object, validatorProvider, rulesEngineOptions);
+            RulesEngine<ContentType, ConditionType> sut = new RulesEngine<ContentType, ConditionType>(mockConditionsEvalEngine.Object, mockRulesDataSource.Object, validatorProvider, rulesEngineOptions, mockCondtionTypeExtractor.Object);
 
             // Act
             Rule<ContentType, ConditionType> actual = await sut.MatchOneAsync(contentType, matchDateTime, conditions);
@@ -354,10 +366,12 @@ namespace Rules.Framework.Tests
             };
             Mock<IRulesDataSource<ContentType, ConditionType>> mockRulesDataSource = SetupMockForRulesDataSource(rules);
             Mock<IConditionsEvalEngine<ConditionType>> mockConditionsEvalEngine = SetupMockForConditionsEvalEngine(true, evaluationOptions);
+
+            Mock<IConditionTypeExtractor<ContentType, ConditionType>> mockCondtionTypeExtractor = new Mock<IConditionTypeExtractor<ContentType, ConditionType>>();
             IValidatorProvider validatorProvider = Mock.Of<IValidatorProvider>();
             RulesEngineOptions rulesEngineOptions = RulesEngineOptions.NewWithDefaults();
 
-            RulesEngine<ContentType, ConditionType> sut = new RulesEngine<ContentType, ConditionType>(mockConditionsEvalEngine.Object, mockRulesDataSource.Object, validatorProvider, rulesEngineOptions);
+            RulesEngine<ContentType, ConditionType> sut = new RulesEngine<ContentType, ConditionType>(mockConditionsEvalEngine.Object, mockRulesDataSource.Object, validatorProvider, rulesEngineOptions, mockCondtionTypeExtractor.Object);
 
             // Act
             Rule<ContentType, ConditionType> actual = await sut.MatchOneAsync(contentType, matchDateTime, conditions);
@@ -419,10 +433,13 @@ namespace Rules.Framework.Tests
             };
             Mock<IRulesDataSource<ContentType, ConditionType>> mockRulesDataSource = SetupMockForRulesDataSource(rules);
             Mock<IConditionsEvalEngine<ConditionType>> mockConditionsEvalEngine = SetupMockForConditionsEvalEngine(false, evaluationOptions);
+
+            Mock<IConditionTypeExtractor<ContentType, ConditionType>> mockCondtionTypeExtractor = new Mock<IConditionTypeExtractor<ContentType, ConditionType>>();
+
             IValidatorProvider validatorProvider = Mock.Of<IValidatorProvider>();
             RulesEngineOptions rulesEngineOptions = RulesEngineOptions.NewWithDefaults();
 
-            RulesEngine<ContentType, ConditionType> sut = new RulesEngine<ContentType, ConditionType>(mockConditionsEvalEngine.Object, mockRulesDataSource.Object, validatorProvider, rulesEngineOptions);
+            RulesEngine<ContentType, ConditionType> sut = new RulesEngine<ContentType, ConditionType>(mockConditionsEvalEngine.Object, mockRulesDataSource.Object, validatorProvider, rulesEngineOptions, mockCondtionTypeExtractor.Object);
 
             // Act
             Rule<ContentType, ConditionType> actual = await sut.MatchOneAsync(contentType, matchDateTime, conditions);
@@ -470,6 +487,9 @@ namespace Rules.Framework.Tests
             {
                 MatchMode = MatchModes.Exact
             };
+
+            Mock<IConditionTypeExtractor<ContentType, ConditionType>> mockCondtionTypeExtractor = new Mock<IConditionTypeExtractor<ContentType, ConditionType>>();
+
             Mock<IRulesDataSource<ContentType, ConditionType>> mockRulesDataSource = SetupMockForRulesDataSource(rules);
             Mock<IConditionsEvalEngine<ConditionType>> mockConditionsEvalEngine = SetupMockForConditionsEvalEngine(false, evaluationOptions);
 
@@ -484,7 +504,7 @@ namespace Rules.Framework.Tests
                 .Returns(validator);
             RulesEngineOptions rulesEngineOptions = RulesEngineOptions.NewWithDefaults();
 
-            RulesEngine<ContentType, ConditionType> sut = new RulesEngine<ContentType, ConditionType>(mockConditionsEvalEngine.Object, mockRulesDataSource.Object, validatorProvider, rulesEngineOptions);
+            RulesEngine<ContentType, ConditionType> sut = new RulesEngine<ContentType, ConditionType>(mockConditionsEvalEngine.Object, mockRulesDataSource.Object, validatorProvider, rulesEngineOptions, mockCondtionTypeExtractor.Object);
 
             // Act
             ArgumentException argumentException = await Assert.ThrowsAsync<ArgumentException>(() => sut.SearchAsync(searchArgs)).ConfigureAwait(false);
@@ -528,12 +548,15 @@ namespace Rules.Framework.Tests
             {
                 MatchMode = MatchModes.Exact
             };
+
+            Mock<IConditionTypeExtractor<ContentType, ConditionType>> mockCondtionTypeExtractor = new Mock<IConditionTypeExtractor<ContentType, ConditionType>>();
+
             Mock<IRulesDataSource<ContentType, ConditionType>> mockRulesDataSource = SetupMockForRulesDataSource(rules);
             Mock<IConditionsEvalEngine<ConditionType>> mockConditionsEvalEngine = SetupMockForConditionsEvalEngine(false, evaluationOptions);
             IValidatorProvider validatorProvider = Mock.Of<IValidatorProvider>();
             RulesEngineOptions rulesEngineOptions = RulesEngineOptions.NewWithDefaults();
 
-            RulesEngine<ContentType, ConditionType> sut = new RulesEngine<ContentType, ConditionType>(mockConditionsEvalEngine.Object, mockRulesDataSource.Object, validatorProvider, rulesEngineOptions);
+            RulesEngine<ContentType, ConditionType> sut = new RulesEngine<ContentType, ConditionType>(mockConditionsEvalEngine.Object, mockRulesDataSource.Object, validatorProvider, rulesEngineOptions, mockCondtionTypeExtractor.Object);
 
             // Act
             ArgumentNullException argumentNullException = await Assert.ThrowsAsync<ArgumentNullException>(() => sut.SearchAsync(searchArgs)).ConfigureAwait(false);

--- a/tests/Rules.Framework.Tests/RulesEngineTests.cs
+++ b/tests/Rules.Framework.Tests/RulesEngineTests.cs
@@ -102,23 +102,17 @@ namespace Rules.Framework.Tests
                 RootCondition = new ValueConditionNode<ConditionType>(DataTypes.String, ConditionType.IsoCountryCode, Operators.Equal, "CHE")
             };
 
-            IEnumerable<Rule<ContentType, ConditionType>> rules = new[]
-            {
-                rule1,
-                rule3
-            };
-
             EvaluationOptions evaluationOptions = new EvaluationOptions
             {
                 MatchMode = MatchModes.Exact
             };
 
-            var expectedCondtionTypes = new List<ConditionType>() { ConditionType.IsoCountryCode };
+            var expectedCondtionTypes = new List<ConditionType> { ConditionType.IsoCountryCode };
 
             mockCondtionTypeExtractor.Setup(x => x.GetConditionTypes(It.IsAny<IEnumerable<Rule<ContentType, ConditionType>>>()))
                 .Returns(expectedCondtionTypes);
 
-            this.SetupMockForConditionsEvalEngine((rootConditionNode, inputConditions, evalOptions) =>
+            this.SetupMockForConditionsEvalEngine((rootConditionNode, _, evalOptions) =>
             {
                 switch (rootConditionNode)
                 {


### PR DESCRIPTION
## Description

The purpose is to be able to fetch the unique condition types associated with the rules persisted on the data source for a specific content type.

i.e. content-type "ABC" has condition types 1 and 2 for rules between dates A and B, and this functionality would let us know that we would need to fill conditions 1 and 2 for rules evaluation on date interval between A and B.

Closes #22 .

## Change checklist

- [x] Code follows the [code rules guidelines](../CONTRIBUTING.md#code-rules) of this project
- [x] Commit messages follow the [commit rules](../CONTRIBUTING.md#commit-rules) of this project
- [x] I have self-reviewed my changes before submitting this pull request
- [x] I have covered new/changed code with new tests and/or adjusted existent ones
- [x] I have made changes necessary to update the documentation accordingly

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)