### PR TITLE
fix: Re-add addDays in rules engine

### DIFF
--- a/src/Rules.Framework/RulesEngine.cs
+++ b/src/Rules.Framework/RulesEngine.cs
@@ -112,7 +112,7 @@ namespace Rules.Framework
             };
 
             DateTime dateBegin = matchDateTime.Date;
-            DateTime dateEnd = matchDateTime.Date;
+            DateTime dateEnd = matchDateTime.Date.AddDays(1);
 
             return this.MatchAsync(contentType, dateBegin, dateEnd, conditions, evaluationOptions);
         }


### PR DESCRIPTION
## Description
Re-adds the AddDays(1) instruction to the RulesEngine, done in [this fix](https://github.com/Farfetch/rules-framework/pull/71) (it didn't solve the issue)

## Change checklist

- [x] Code follows the [code rules guidelines](../CONTRIBUTING.md#code-rules) of this project
- [x] Commit messages follow the [commit rules](../CONTRIBUTING.md#commit-rules) of this project
- [x] I have self-reviewed my changes before submitting this pull request
- [ ] I have covered new/changed code with new tests and/or adjusted existent ones
- [ ] I have made changes necessary to update the documentation accordingly

Please also check the [_I want to contribute_](../CONTRIBUTING.md#i-want-to-contribute) guidelines and make sure you have done accordingly.

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)