### PR TITLE
feat: add support for notStartsWith and notEndsWith operators

### DIFF
--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -40,7 +40,7 @@ jobs:
         git fetch --tags --force
 
         # deal with forked repositories
-        git remote add upstream $REPOSITORY_NAME
+        git remote add upstream https://github.com/${{ github.repository }}
         git fetch --tags upstream
 
     - name: Find last tag

--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -35,7 +35,13 @@ jobs:
         repository: ${{github.event.pull_request.head.repo.full_name}}
 
     - name: Force fetch tags
-      run: git fetch --tags --force
+      run: |
+        # get current repository tags
+        git fetch --tags --force
+
+        # deal with forked repositories
+        git remote add upstream $REPOSITORY_NAME
+        git fetch --tags upstream
 
     - name: Find last tag
       id: prev-version-tag

--- a/docs/add-rules.md
+++ b/docs/add-rules.md
@@ -101,6 +101,8 @@ Next step is to define a comparison operator using method `WithComparisonOperato
 - EndsWith
 - CaseInsensitiveStartsWith
 - CaseInsensitiveEndsWith
+- NotStartsWith
+- NotEndsWith
 
 Not all comparison operators are supported for all data types, some combinations of them are not valid. This will be validated by rule builder and a validation error will be returned if a invalid combination is attempted. Check the following grid to see combinations are valid or not:
 
@@ -118,6 +120,8 @@ Not all comparison operators are supported for all data types, some combinations
 |EndsWith|:x:|:x:|:x:|:heavy_check_mark:|
 |CaseInsensitiveStartsWith|:x:|:x:|:x:|:heavy_check_mark:|
 |CaseInsensitiveEndsWith|:x:|:x:|:x:|:heavy_check_mark:|
+|NotStartsWith|:x:|:x:|:x:|:heavy_check_mark:|
+|NotEndsWith|:x:|:x:|:x:|:heavy_check_mark:|
 
 You should also take into consideration the multiplicity of operands when setting value conditions on a rule. Theoretically, all multiplicity combinations are supported (one to one, one to many, many to one, many to many), but that also relies on a per-operator implementation for each multiplicity. Please refer to following combinations to see which multiplicities are supported or not:
 
@@ -135,6 +139,8 @@ You should also take into consideration the multiplicity of operands when settin
 |EndsWith|:heavy_check_mark:|:x:|:x:|:x:|
 |CaseInsensitiveStartsWith|:heavy_check_mark:|:x:|:x:|:x:|
 |CaseInsensitiveEndsWith|:heavy_check_mark:|:x:|:x:|:x:|
+|NotStartsWith|:heavy_check_mark:|:x:|:x:|:x:|
+|NotEndsWith|:heavy_check_mark:|:x:|:x:|:x:|
 
 At last, you should complete valued condition node build with a right hand operand with following methods, according to wanted multiplicity:
 

--- a/src/Rules.Framework/Builder/Validation/ValueConditionNodeValidator.cs
+++ b/src/Rules.Framework/Builder/Validation/ValueConditionNodeValidator.cs
@@ -19,7 +19,7 @@ namespace Rules.Framework.Builder.Validation
             this.RuleFor(c => c.Operator).IsInEnum();
 
             this.RuleFor(c => c.Operator)
-                .IsContainedOn(Operators.Equal, Operators.NotEqual, Operators.Contains, Operators.NotContains, Operators.In, Operators.StartsWith, Operators.EndsWith, Operators.CaseInsensitiveStartsWith, Operators.CaseInsensitiveEndsWith)
+                .IsContainedOn(Operators.Equal, Operators.NotEqual, Operators.Contains, Operators.NotContains, Operators.In, Operators.StartsWith, Operators.EndsWith, Operators.CaseInsensitiveStartsWith, Operators.CaseInsensitiveEndsWith, Operators.NotStartsWith, Operators.NotEndsWith)
                 .When(c => c.DataType == DataTypes.String)
                 .WithMessage(cn => $"Condition nodes with data type '{cn.DataType}' can't define a operator of type '{cn.Operator}'.");
 

--- a/src/Rules.Framework/Core/Operators.cs
+++ b/src/Rules.Framework/Core/Operators.cs
@@ -68,6 +68,16 @@ namespace Rules.Framework.Core
         /// <summary>
         /// The ends with operator.
         /// </summary>
-        CaseInsensitiveEndsWith = 13
+        CaseInsensitiveEndsWith = 13,
+
+        /// <summary>
+        /// The not starts with operator.
+        /// </summary>
+        NotStartsWith = 14,
+
+        /// <summary>
+        /// The not ends with operator.
+        /// </summary>
+        NotEndsWith = 15
     }
 }

--- a/src/Rules.Framework/Evaluation/ValueEvaluation/Dispatchers/ConditionEvalDispatchProvider.cs
+++ b/src/Rules.Framework/Evaluation/ValueEvaluation/Dispatchers/ConditionEvalDispatchProvider.cs
@@ -40,7 +40,9 @@ namespace Rules.Framework.Evaluation.ValueEvaluation.Dispatchers
                 $"{OneToOne}-{Operators.StartsWith}",
                 $"{OneToOne}-{Operators.EndsWith}",
                 $"{OneToOne}-{Operators.CaseInsensitiveStartsWith}",
-                $"{OneToOne}-{Operators.CaseInsensitiveEndsWith}"
+                $"{OneToOne}-{Operators.CaseInsensitiveEndsWith}",
+                $"{OneToOne}-{Operators.NotStartsWith}",
+                $"{OneToOne}-{Operators.NotEndsWith}"
             };
         }
 

--- a/src/Rules.Framework/Evaluation/ValueEvaluation/NotEndsWithOperatorEvalStrategy.cs
+++ b/src/Rules.Framework/Evaluation/ValueEvaluation/NotEndsWithOperatorEvalStrategy.cs
@@ -1,0 +1,20 @@
+namespace Rules.Framework.Evaluation.ValueEvaluation
+{
+    using System;
+
+    internal class NotEndsWithOperatorEvalStrategy : IOneToOneOperatorEvalStrategy
+    {
+        public bool Eval(object leftOperand, object rightOperand)
+        {
+            if (leftOperand is string && rightOperand is string)
+            {
+                var leftOperandAsString = leftOperand as string;
+                var rightOperandAsString = rightOperand as string;
+
+                return !leftOperandAsString.EndsWith(rightOperandAsString);
+            }
+
+            throw new NotSupportedException($"Only operands of type {nameof(String)} supported.");
+        }
+    }
+}

--- a/src/Rules.Framework/Evaluation/ValueEvaluation/NotStartsWithOperatorEvalStrategy.cs
+++ b/src/Rules.Framework/Evaluation/ValueEvaluation/NotStartsWithOperatorEvalStrategy.cs
@@ -1,0 +1,20 @@
+namespace Rules.Framework.Evaluation.ValueEvaluation
+{
+    using System;
+
+    internal class NotStartsWithOperatorEvalStrategy : IOneToOneOperatorEvalStrategy
+    {
+        public bool Eval(object leftOperand, object rightOperand)
+        {
+            if (leftOperand is string && rightOperand is string)
+            {
+                var leftOperandAsString = leftOperand as string;
+                var rightOperandAsString = rightOperand as string;
+
+                return !leftOperandAsString.StartsWith(rightOperandAsString);
+            }
+
+            throw new NotSupportedException($"Only operands of type {nameof(String)} supported.");
+        }
+    }
+}

--- a/src/Rules.Framework/Evaluation/ValueEvaluation/OperatorEvalStrategyFactory.cs
+++ b/src/Rules.Framework/Evaluation/ValueEvaluation/OperatorEvalStrategyFactory.cs
@@ -24,7 +24,9 @@ namespace Rules.Framework.Evaluation.ValueEvaluation
                 { Operators.StartsWith, new StartsWithOperatorEvalStrategy() },
                 { Operators.EndsWith, new EndsWithOperatorEvalStrategy() },
                 { Operators.CaseInsensitiveStartsWith, new CaseInsensitiveStartsWithOperatorEvalStrategy() },
-                { Operators.CaseInsensitiveEndsWith, new CaseInsensitiveEndsWithOperatorEvalStrategy() }
+                { Operators.CaseInsensitiveEndsWith, new CaseInsensitiveEndsWithOperatorEvalStrategy() },
+                { Operators.NotStartsWith, new NotStartsWithOperatorEvalStrategy() },
+                { Operators.NotEndsWith, new NotEndsWithOperatorEvalStrategy() }
             };
         }
 

--- a/tests/Rules.Framework.Tests/Evaluation/ValueEvaluation/NotEndsWithOperatorEvalStrategyTests.cs
+++ b/tests/Rules.Framework.Tests/Evaluation/ValueEvaluation/NotEndsWithOperatorEvalStrategyTests.cs
@@ -1,0 +1,55 @@
+namespace Rules.Framework.Tests.Evaluation.ValueEvaluation
+{
+    using System;
+    using Rules.Framework.Evaluation.ValueEvaluation;
+    using Xunit;
+
+    public class NotEndsWithOperatorEvalStrategyTests
+    {
+        private readonly NotEndsWithOperatorEvalStrategy evalStrategy;
+
+        public NotEndsWithOperatorEvalStrategyTests()
+        {
+            evalStrategy = new NotEndsWithOperatorEvalStrategy();
+        }
+
+        [Theory]
+        [InlineData(2, "test")]
+        [InlineData("test", false)]
+        [InlineData(2, false)]
+        public void Eval_GivenInvalidOperandCombination_ThrowsNotSupportedOperation(object leftOperand, object rightOperand)
+        {
+            // Act
+            var exception = Assert.Throws<NotSupportedException>(() => evalStrategy.Eval(leftOperand, rightOperand));
+
+            // Assert
+            Assert.Contains(nameof(String), exception.Message);
+        }
+
+        [Theory]
+        [InlineData("Sample text", "random")]
+        [InlineData("Sample text", "Text")]
+        public void Eval_GivenLeftOperandNotEndingWithRightOperand_ReturnsTrue(string leftOperand, string rightOperand)
+        {
+            // Act
+            var evaluation = evalStrategy.Eval(leftOperand, rightOperand);
+
+            // Assert
+            Assert.True(evaluation);
+        }
+
+        [Fact]
+        public void Eval_GivenLeftOperandEndingWithRightOperand_ReturnsFalse()
+        {
+            // Arrange
+            var leftOperand = "Sample text";
+            var rightOperand = "text";
+
+            // Act
+            var evaluation = evalStrategy.Eval(leftOperand, rightOperand);
+
+            // Assert
+            Assert.False(evaluation);
+        }
+    }
+}

--- a/tests/Rules.Framework.Tests/Evaluation/ValueEvaluation/NotStartsWithOperatorEvalStrategyTests.cs
+++ b/tests/Rules.Framework.Tests/Evaluation/ValueEvaluation/NotStartsWithOperatorEvalStrategyTests.cs
@@ -1,0 +1,55 @@
+namespace Rules.Framework.Tests.Evaluation.ValueEvaluation
+{
+    using System;
+    using Rules.Framework.Evaluation.ValueEvaluation;
+    using Xunit;
+
+    public class NotStartsWithOperatorEvalStrategyTests
+    {
+        private readonly NotStartsWithOperatorEvalStrategy evalStrategy;
+
+        public NotStartsWithOperatorEvalStrategyTests()
+        {
+            evalStrategy = new NotStartsWithOperatorEvalStrategy();
+        }
+
+        [Theory]
+        [InlineData(2, "test")]
+        [InlineData("test", false)]
+        [InlineData(2, false)]
+        public void Eval_GivenInvalidOperandCombination_ThrowsNotSupportedOperation(object leftOperand, object rightOperand)
+        {
+            // Act
+            var exception = Assert.Throws<NotSupportedException>(() => evalStrategy.Eval(leftOperand, rightOperand));
+
+            // Assert
+            Assert.Contains(nameof(String), exception.Message);
+        }
+
+        [Theory]
+        [InlineData("Sample text", "random")]
+        [InlineData("Sample text", "sample")]
+        public void Eval_GivenLeftOperandNotStartingWithRightOperand_ReturnsTrue(string leftOperand, string rightOperand)
+        {
+            // Act
+            var evaluation = evalStrategy.Eval(leftOperand, rightOperand);
+
+            // Assert
+            Assert.True(evaluation);
+        }
+
+        [Fact]
+        public void Eval_GivenLeftOperandStartingWithRightOperand_ReturnsFalse()
+        {
+            // Arrange
+            var leftOperand = "Sample text";
+            var rightOperand = "Sample";
+
+            // Act
+            var evaluation = evalStrategy.Eval(leftOperand, rightOperand);
+
+            // Assert
+            Assert.False(evaluation);
+        }
+    }
+}

--- a/tests/Rules.Framework.Tests/Evaluation/ValueEvaluation/OperatorEvalStrategyFactoryTests.cs
+++ b/tests/Rules.Framework.Tests/Evaluation/ValueEvaluation/OperatorEvalStrategyFactoryTests.cs
@@ -161,6 +161,12 @@ namespace Rules.Framework.Tests.Evaluation.ValueEvaluation
         [InlineData(Operators.LesserThanOrEqual, typeof(LesserThanOrEqualOperatorEvalStrategy))]
         [InlineData(Operators.Contains, typeof(ContainsOperatorEvalStrategy))]
         [InlineData(Operators.NotContains, typeof(NotContainsOperatorEvalStrategy))]
+        [InlineData(Operators.StartsWith, typeof(StartsWithOperatorEvalStrategy))]
+        [InlineData(Operators.EndsWith, typeof(EndsWithOperatorEvalStrategy))]
+        [InlineData(Operators.CaseInsensitiveStartsWith, typeof(CaseInsensitiveStartsWithOperatorEvalStrategy))]
+        [InlineData(Operators.CaseInsensitiveEndsWith, typeof(CaseInsensitiveEndsWithOperatorEvalStrategy))]
+        [InlineData(Operators.NotStartsWith, typeof(NotStartsWithOperatorEvalStrategy))]
+        [InlineData(Operators.NotEndsWith, typeof(NotEndsWithOperatorEvalStrategy))]
         public void GetOneToOneOperatorEvalStrategy_GivenOperator_ReturnsOperatorEvalStrategy(Operators @operator, Type type)
         {
             // Arrange


### PR DESCRIPTION
## Description

Implements support for the "NotStartsWith" and "NotEndsWith" operators.

- Issue #91 

## Change checklist

- [x] Code follows the [code rules guidelines](../CONTRIBUTING.md#code-rules) of this project
- [x] Commit messages follow the [commit rules](../CONTRIBUTING.md#commit-rules) of this project
- [x] I have self-reviewed my changes before submitting this pull request
- [x] I have covered new/changed code with new tests and/or adjusted existent ones
- [x] I have made changes necessary to update the documentation accordingly

Please also check the [_I want to contribute_](../CONTRIBUTING.md#i-want-to-contribute) guidelines and make sure you have done accordingly.

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)