### PR TITLE
Performance improvements to codebase

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -198,9 +198,39 @@ dotnet_naming_style.begins_with_i.capitalization = pascal_case
 # CA1303: Do not pass literals as localized parameters
 dotnet_diagnostic.CA1303.severity = none
 
+dotnet_diagnostic.MA0053.severity = suggestion
+MA0053.public_class_should_be_sealed = false
+MA0053.class_with_virtual_member_shoud_be_sealed = true
+
 [*]
 charset = utf-8
 trim_trailing_whitespace = true
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
+dotnet_style_prefer_auto_properties = true:silent
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_prefer_simplified_boolean_expressions = true:suggestion
+dotnet_style_prefer_conditional_expression_over_assignment = true:silent
+dotnet_style_prefer_conditional_expression_over_return = true:silent
+dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
+dotnet_style_prefer_compound_assignment = true:suggestion
+csharp_style_namespace_declarations = block_scoped:silent
+csharp_style_prefer_method_group_conversion = true:silent
+csharp_style_prefer_top_level_statements = true:silent
+dotnet_style_operator_placement_when_wrapping = beginning_of_line
+tab_width = 4
+indent_size = 4
+end_of_line = lf
+dotnet_style_prefer_simplified_interpolation = true:suggestion
+csharp_style_prefer_extended_property_pattern = true:suggestion
+dotnet_style_namespace_match_folder = true:suggestion
+csharp_style_prefer_switch_expression = true:suggestion
+csharp_style_prefer_pattern_matching = true:silent
+csharp_style_prefer_not_pattern = true:suggestion
 
 [*.vb]
 visual_basic_preferred_modifier_order = Partial,Default,Private,Protected,Public,Friend,NotOverridable,Overridable,MustOverride,Overloads,Overrides,MustInherit,NotInheritable,Static,Shared,Shadows,ReadOnly,WriteOnly,Dim,Const,WithEvents,Widening,Narrowing,Custom,Async:suggestion:suggestion

--- a/src/Rules.Framework.Providers.InMemory/DataModel/ComposedConditionNodeDataModel.cs
+++ b/src/Rules.Framework.Providers.InMemory/DataModel/ComposedConditionNodeDataModel.cs
@@ -2,7 +2,7 @@ namespace Rules.Framework.Providers.InMemory.DataModel
 {
     using System.Collections.Generic;
 
-    internal class ComposedConditionNodeDataModel<TConditionType> : ConditionNodeDataModel<TConditionType>
+    internal sealed class ComposedConditionNodeDataModel<TConditionType> : ConditionNodeDataModel<TConditionType>
     {
         public IEnumerable<ConditionNodeDataModel<TConditionType>> ChildConditionNodes { get; set; }
     }

--- a/src/Rules.Framework.Providers.InMemory/DataModel/RuleDataModel.cs
+++ b/src/Rules.Framework.Providers.InMemory/DataModel/RuleDataModel.cs
@@ -2,7 +2,7 @@ namespace Rules.Framework.Providers.InMemory.DataModel
 {
     using System;
 
-    internal class RuleDataModel<TContentType, TConditionType>
+    internal sealed class RuleDataModel<TContentType, TConditionType>
     {
         public dynamic Content { get; set; }
 

--- a/src/Rules.Framework.Providers.InMemory/DataModel/ValueConditionNodeDataModel.cs
+++ b/src/Rules.Framework.Providers.InMemory/DataModel/ValueConditionNodeDataModel.cs
@@ -2,7 +2,7 @@ namespace Rules.Framework.Providers.InMemory.DataModel
 {
     using Rules.Framework.Core;
 
-    internal class ValueConditionNodeDataModel<TConditionType> : ConditionNodeDataModel<TConditionType>
+    internal sealed class ValueConditionNodeDataModel<TConditionType> : ConditionNodeDataModel<TConditionType>
     {
         public TConditionType ConditionType { get; set; }
 

--- a/src/Rules.Framework.Providers.InMemory/InMemoryRulesStorage.cs
+++ b/src/Rules.Framework.Providers.InMemory/InMemoryRulesStorage.cs
@@ -6,7 +6,7 @@ namespace Rules.Framework.Providers.InMemory
     using System.Linq;
     using Rules.Framework.Providers.InMemory.DataModel;
 
-    internal class InMemoryRulesStorage<TContentType, TConditionType> : IInMemoryRulesStorage<TContentType, TConditionType>
+    internal sealed class InMemoryRulesStorage<TContentType, TConditionType> : IInMemoryRulesStorage<TContentType, TConditionType>
     {
         private readonly ConcurrentDictionary<TContentType, List<RuleDataModel<TContentType, TConditionType>>> rulesByContentType;
 

--- a/src/Rules.Framework.Providers.InMemory/RuleFactory.cs
+++ b/src/Rules.Framework.Providers.InMemory/RuleFactory.cs
@@ -18,7 +18,7 @@ namespace Rules.Framework.Providers.InMemory
                 throw new ArgumentNullException(nameof(ruleDataModel));
             }
 
-            var contentContainer = new ContentContainer<TContentType>(ruleDataModel.ContentType, (t) => ruleDataModel.Content);
+            var contentContainer = new ContentContainer<TContentType>(ruleDataModel.ContentType, (_) => ruleDataModel.Content);
             var ruleBuilderResult = RuleBuilder.NewRule<TContentType, TConditionType>()
                 .WithName(ruleDataModel.Name)
                 .WithDatesInterval(ruleDataModel.DateBegin, ruleDataModel.DateEnd)

--- a/src/Rules.Framework.Providers.InMemory/Rules.Framework.Providers.InMemory.csproj
+++ b/src/Rules.Framework.Providers.InMemory/Rules.Framework.Providers.InMemory.csproj
@@ -27,7 +27,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3">
+    <PackageReference Include="Meziantou.Analyzer" Version="1.0.756">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Rules.Framework.Providers.MongoDb/DataModel/ComposedConditionNodeDataModel.cs
+++ b/src/Rules.Framework.Providers.MongoDb/DataModel/ComposedConditionNodeDataModel.cs
@@ -5,7 +5,7 @@ namespace Rules.Framework.Providers.MongoDb.DataModel
     using MongoDB.Bson.Serialization.Attributes;
 
     [BsonDiscriminator("composed")]
-    internal class ComposedConditionNodeDataModel : ConditionNodeDataModel
+    internal sealed class ComposedConditionNodeDataModel : ConditionNodeDataModel
     {
         public IEnumerable<ConditionNodeDataModel> ChildConditionNodes { get; set; }
     }

--- a/src/Rules.Framework.Providers.MongoDb/DataModel/RuleDataModel.cs
+++ b/src/Rules.Framework.Providers.MongoDb/DataModel/RuleDataModel.cs
@@ -3,7 +3,7 @@ namespace Rules.Framework.Providers.MongoDb.DataModel
     using System;
     using MongoDB.Bson.Serialization.Attributes;
 
-    internal class RuleDataModel
+    internal sealed class RuleDataModel
     {
         public dynamic Content { get; set; }
 

--- a/src/Rules.Framework.Providers.MongoDb/DataModel/ValueConditionNodeDataModel.cs
+++ b/src/Rules.Framework.Providers.MongoDb/DataModel/ValueConditionNodeDataModel.cs
@@ -5,7 +5,7 @@ namespace Rules.Framework.Providers.MongoDb.DataModel
     using Rules.Framework.Core;
 
     [BsonDiscriminator("value")]
-    internal class ValueConditionNodeDataModel : ConditionNodeDataModel
+    internal sealed class ValueConditionNodeDataModel : ConditionNodeDataModel
     {
         [BsonElement(Order = 1)]
         public string ConditionType { get; set; }

--- a/src/Rules.Framework.Providers.MongoDb/RuleFactory.cs
+++ b/src/Rules.Framework.Providers.MongoDb/RuleFactory.cs
@@ -10,7 +10,7 @@ namespace Rules.Framework.Providers.MongoDb
     using Rules.Framework.Providers.MongoDb.DataModel;
     using Rules.Framework.Serialization;
 
-    internal class RuleFactory<TContentType, TConditionType> : IRuleFactory<TContentType, TConditionType>
+    internal sealed class RuleFactory<TContentType, TConditionType> : IRuleFactory<TContentType, TConditionType>
     {
         private readonly IContentSerializationProvider<TContentType> contentSerializationProvider;
 
@@ -26,12 +26,12 @@ namespace Rules.Framework.Providers.MongoDb
                 throw new ArgumentNullException(nameof(ruleDataModel));
             }
 
-            TContentType contentType = Parse<TContentType>(ruleDataModel.ContentType);
+            var contentType = Parse<TContentType>(ruleDataModel.ContentType);
 
-            RuleBuilderResult<TContentType, TConditionType> ruleBuilderResult = RuleBuilder.NewRule<TContentType, TConditionType>()
+            var ruleBuilderResult = RuleBuilder.NewRule<TContentType, TConditionType>()
                 .WithName(ruleDataModel.Name)
                 .WithDatesInterval(ruleDataModel.DateBegin, ruleDataModel.DateEnd)
-                .WithCondition(cnb => ruleDataModel.RootCondition is { } ? this.ConvertConditionNode(cnb, ruleDataModel.RootCondition) : null)
+                .WithCondition(cnb => ruleDataModel.RootCondition is { } ? ConvertConditionNode(cnb, ruleDataModel.RootCondition) : null)
                 .WithSerializedContent(contentType, (object)ruleDataModel.Content, this.contentSerializationProvider)
                 .Build();
 
@@ -59,9 +59,9 @@ namespace Rules.Framework.Providers.MongoDb
                 throw new ArgumentNullException(nameof(rule));
             }
 
-            dynamic content = rule.ContentContainer.GetContentAs<dynamic>();
+            var content = rule.ContentContainer.GetContentAs<dynamic>();
 
-            RuleDataModel ruleDataModel = new RuleDataModel
+            var ruleDataModel = new RuleDataModel
             {
                 Content = content,
                 ContentType = Convert.ToString(rule.ContentContainer.ContentType, CultureInfo.InvariantCulture),
@@ -69,11 +69,76 @@ namespace Rules.Framework.Providers.MongoDb
                 DateEnd = rule.DateEnd,
                 Name = rule.Name,
                 Priority = rule.Priority,
-                RootCondition = rule.RootCondition is { } ? this.ConvertConditionNode(rule.RootCondition) : null
+                RootCondition = rule.RootCondition is { } ? ConvertConditionNode(rule.RootCondition) : null,
             };
 
             return ruleDataModel;
         }
+
+        private static ValueConditionNodeDataModel ConvertBooleanConditionNode(BooleanConditionNode<TConditionType> booleanConditionNode) => new ValueConditionNodeDataModel
+        {
+            ConditionType = Convert.ToString(booleanConditionNode.ConditionType, CultureInfo.InvariantCulture),
+            LogicalOperator = LogicalOperators.Eval,
+            DataType = booleanConditionNode.DataType,
+            Operand = booleanConditionNode.Operand,
+            Operator = booleanConditionNode.Operator,
+        };
+
+        private static IConditionNode<TConditionType> ConvertConditionNode(IConditionNodeBuilder<TConditionType> conditionNodeBuilder, ConditionNodeDataModel conditionNodeDataModel)
+        {
+            if (conditionNodeDataModel.LogicalOperator == LogicalOperators.Eval)
+            {
+                return CreateValueConditionNode(conditionNodeBuilder, conditionNodeDataModel as ValueConditionNodeDataModel);
+            }
+
+            ComposedConditionNodeDataModel composedConditionNodeDataModel = conditionNodeDataModel as ComposedConditionNodeDataModel;
+
+            IComposedConditionNodeBuilder<TConditionType> composedConditionNodeBuilder = conditionNodeBuilder.AsComposed()
+                .WithLogicalOperator(composedConditionNodeDataModel.LogicalOperator);
+
+            foreach (ConditionNodeDataModel child in composedConditionNodeDataModel.ChildConditionNodes)
+            {
+                composedConditionNodeBuilder.AddCondition(cnb => ConvertConditionNode(cnb, child));
+            }
+
+            return composedConditionNodeBuilder.Build();
+        }
+
+        private static ValueConditionNodeDataModel ConvertDecimalConditionNode(DecimalConditionNode<TConditionType> decimalConditionNode) => new ValueConditionNodeDataModel
+        {
+            ConditionType = Convert.ToString(decimalConditionNode.ConditionType, CultureInfo.InvariantCulture),
+            LogicalOperator = LogicalOperators.Eval,
+            DataType = decimalConditionNode.DataType,
+            Operand = decimalConditionNode.Operand,
+            Operator = decimalConditionNode.Operator,
+        };
+
+        private static ValueConditionNodeDataModel ConvertIntegerConditionNode(IntegerConditionNode<TConditionType> integerConditionNode) => new ValueConditionNodeDataModel
+        {
+            ConditionType = Convert.ToString(integerConditionNode.ConditionType, CultureInfo.InvariantCulture),
+            LogicalOperator = LogicalOperators.Eval,
+            DataType = integerConditionNode.DataType,
+            Operand = integerConditionNode.Operand,
+            Operator = integerConditionNode.Operator,
+        };
+
+        private static ValueConditionNodeDataModel ConvertStringConditionNode(StringConditionNode<TConditionType> stringConditionNode) => new ValueConditionNodeDataModel
+        {
+            ConditionType = Convert.ToString(stringConditionNode.ConditionType, CultureInfo.InvariantCulture),
+            LogicalOperator = LogicalOperators.Eval,
+            DataType = stringConditionNode.DataType,
+            Operand = stringConditionNode.Operand,
+            Operator = stringConditionNode.Operator,
+        };
+
+        private static ValueConditionNodeDataModel ConvertValueConditionNode(ValueConditionNode<TConditionType> valueConditionNode) => new ValueConditionNodeDataModel
+        {
+            ConditionType = Convert.ToString(valueConditionNode.ConditionType, CultureInfo.InvariantCulture),
+            LogicalOperator = LogicalOperators.Eval,
+            DataType = valueConditionNode.DataType,
+            Operand = valueConditionNode.Operand,
+            Operator = valueConditionNode.Operator,
+        };
 
         private static IConditionNode<TConditionType> CreateValueConditionNode(IConditionNodeBuilder<TConditionType> conditionNodeBuilder, ValueConditionNodeDataModel conditionNodeDataModel)
         {
@@ -110,26 +175,19 @@ namespace Rules.Framework.Providers.MongoDb
         private static object Parse(string value, Type type)
             => type.IsEnum ? Enum.Parse(type, value) : Convert.ChangeType(value, type, CultureInfo.InvariantCulture);
 
-        private IConditionNode<TConditionType> ConvertConditionNode(IConditionNodeBuilder<TConditionType> conditionNodeBuilder, ConditionNodeDataModel conditionNodeDataModel)
+        private ConditionNodeDataModel ConvertComposedConditionNode(ComposedConditionNode<TConditionType> composedConditionNode)
         {
-            if (conditionNodeDataModel.LogicalOperator == LogicalOperators.Eval)
+            List<ConditionNodeDataModel> conditionNodeDataModels = new List<ConditionNodeDataModel>(composedConditionNode.ChildConditionNodes.Count());
+            foreach (IConditionNode<TConditionType> child in composedConditionNode.ChildConditionNodes)
             {
-                return CreateValueConditionNode(conditionNodeBuilder, conditionNodeDataModel as ValueConditionNodeDataModel);
+                conditionNodeDataModels.Add(this.ConvertConditionNode(child));
             }
-            else
+
+            return new ComposedConditionNodeDataModel
             {
-                ComposedConditionNodeDataModel composedConditionNodeDataModel = conditionNodeDataModel as ComposedConditionNodeDataModel;
-
-                IComposedConditionNodeBuilder<TConditionType> composedConditionNodeBuilder = conditionNodeBuilder.AsComposed()
-                    .WithLogicalOperator(composedConditionNodeDataModel.LogicalOperator);
-
-                foreach (ConditionNodeDataModel child in composedConditionNodeDataModel.ChildConditionNodes)
-                {
-                    composedConditionNodeBuilder.AddCondition(cnb => this.ConvertConditionNode(cnb, child));
-                }
-
-                return composedConditionNodeBuilder.Build();
-            }
+                ChildConditionNodes = conditionNodeDataModels,
+                LogicalOperator = composedConditionNode.LogicalOperator,
+            };
         }
 
         private ConditionNodeDataModel ConvertConditionNode(IConditionNode<TConditionType> conditionNode)
@@ -138,65 +196,17 @@ namespace Rules.Framework.Providers.MongoDb
             {
                 return conditionNode switch
                 {
-                    BooleanConditionNode<TConditionType> booleanConditionNode => new ValueConditionNodeDataModel
-                    {
-                        ConditionType = Convert.ToString(booleanConditionNode.ConditionType, CultureInfo.InvariantCulture),
-                        LogicalOperator = LogicalOperators.Eval,
-                        DataType = booleanConditionNode.DataType,
-                        Operand = booleanConditionNode.Operand,
-                        Operator = booleanConditionNode.Operator
-                    },
-                    DecimalConditionNode<TConditionType> decimalConditionNode => new ValueConditionNodeDataModel
-                    {
-                        ConditionType = Convert.ToString(decimalConditionNode.ConditionType, CultureInfo.InvariantCulture),
-                        LogicalOperator = LogicalOperators.Eval,
-                        DataType = decimalConditionNode.DataType,
-                        Operand = decimalConditionNode.Operand,
-                        Operator = decimalConditionNode.Operator
-                    },
-                    IntegerConditionNode<TConditionType> integerConditionNode => new ValueConditionNodeDataModel
-                    {
-                        ConditionType = Convert.ToString(integerConditionNode.ConditionType, CultureInfo.InvariantCulture),
-                        LogicalOperator = LogicalOperators.Eval,
-                        DataType = integerConditionNode.DataType,
-                        Operand = integerConditionNode.Operand,
-                        Operator = integerConditionNode.Operator
-                    },
-                    StringConditionNode<TConditionType> stringConditionNode => new ValueConditionNodeDataModel
-                    {
-                        ConditionType = Convert.ToString(stringConditionNode.ConditionType, CultureInfo.InvariantCulture),
-                        LogicalOperator = LogicalOperators.Eval,
-                        DataType = stringConditionNode.DataType,
-                        Operand = stringConditionNode.Operand,
-                        Operator = stringConditionNode.Operator
-                    },
-                    ValueConditionNode<TConditionType> valueConditionNode => new ValueConditionNodeDataModel
-                    {
-                        ConditionType = Convert.ToString(valueConditionNode.ConditionType, CultureInfo.InvariantCulture),
-                        LogicalOperator = LogicalOperators.Eval,
-                        DataType = valueConditionNode.DataType,
-                        Operand = valueConditionNode.Operand,
-                        Operator = valueConditionNode.Operator
-                    },
+                    BooleanConditionNode<TConditionType> booleanConditionNode => ConvertBooleanConditionNode(booleanConditionNode),
+                    DecimalConditionNode<TConditionType> decimalConditionNode => ConvertDecimalConditionNode(decimalConditionNode),
+                    IntegerConditionNode<TConditionType> integerConditionNode => ConvertIntegerConditionNode(integerConditionNode),
+                    StringConditionNode<TConditionType> stringConditionNode => ConvertStringConditionNode(stringConditionNode),
+                    ValueConditionNode<TConditionType> valueConditionNode => ConvertValueConditionNode(valueConditionNode),
                     _ => throw new NotSupportedException($"Unsupported value condition node type: {conditionNode.GetType().FullName}."),
                 };
             }
-            else
-            {
-                ComposedConditionNode<TConditionType> composedConditionNode = conditionNode as ComposedConditionNode<TConditionType>;
 
-                List<ConditionNodeDataModel> conditionNodeDataModels = new List<ConditionNodeDataModel>(composedConditionNode.ChildConditionNodes.Count());
-                foreach (IConditionNode<TConditionType> child in composedConditionNode.ChildConditionNodes)
-                {
-                    conditionNodeDataModels.Add(this.ConvertConditionNode(child));
-                }
-
-                return new ComposedConditionNodeDataModel
-                {
-                    ChildConditionNodes = conditionNodeDataModels,
-                    LogicalOperator = composedConditionNode.LogicalOperator
-                };
-            }
+            ComposedConditionNode<TConditionType> composedConditionNode = conditionNode as ComposedConditionNode<TConditionType>;
+            return ConvertComposedConditionNode(composedConditionNode);
         }
     }
 }

--- a/src/Rules.Framework.Providers.MongoDb/Rules.Framework.Providers.MongoDb.csproj
+++ b/src/Rules.Framework.Providers.MongoDb/Rules.Framework.Providers.MongoDb.csproj
@@ -27,7 +27,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3">
+    <PackageReference Include="Meziantou.Analyzer" Version="1.0.756">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Rules.Framework/Builder/ComposedConditionNodeBuilder.cs
+++ b/src/Rules.Framework/Builder/ComposedConditionNodeBuilder.cs
@@ -5,7 +5,7 @@ namespace Rules.Framework.Builder
     using Rules.Framework.Core;
     using Rules.Framework.Core.ConditionNodes;
 
-    internal class ComposedConditionNodeBuilder<TConditionType> : IComposedConditionNodeBuilder<TConditionType>
+    internal sealed class ComposedConditionNodeBuilder<TConditionType> : IComposedConditionNodeBuilder<TConditionType>
     {
         private readonly IConditionNodeBuilder<TConditionType> conditionNodeBuilder;
         private readonly List<IConditionNode<TConditionType>> conditions;

--- a/src/Rules.Framework/Builder/ConditionNodeBuilder.cs
+++ b/src/Rules.Framework/Builder/ConditionNodeBuilder.cs
@@ -1,6 +1,6 @@
 namespace Rules.Framework.Builder
 {
-    internal class ConditionNodeBuilder<TConditionType> : IConditionNodeBuilder<TConditionType>
+    internal sealed class ConditionNodeBuilder<TConditionType> : IConditionNodeBuilder<TConditionType>
     {
         public IComposedConditionNodeBuilder<TConditionType> AsComposed()
             => new ComposedConditionNodeBuilder<TConditionType>(this);

--- a/src/Rules.Framework/Builder/ConfiguredRulesEngineBuilder.cs
+++ b/src/Rules.Framework/Builder/ConfiguredRulesEngineBuilder.cs
@@ -6,7 +6,7 @@ namespace Rules.Framework.Builder
     using Rules.Framework.Evaluation.ValueEvaluation.Dispatchers;
     using Rules.Framework.Validation;
 
-    internal class ConfiguredRulesEngineBuilder<TContentType, TConditionType> : IConfiguredRulesEngineBuilder<TContentType, TConditionType>
+    internal sealed class ConfiguredRulesEngineBuilder<TContentType, TConditionType> : IConfiguredRulesEngineBuilder<TContentType, TConditionType>
     {
         private readonly IRulesDataSource<TContentType, TConditionType> rulesDataSource;
         private readonly RulesEngineOptions rulesEngineOptions;
@@ -22,12 +22,14 @@ namespace Rules.Framework.Builder
             IOperatorEvalStrategyFactory operatorEvalStrategyFactory = new OperatorEvalStrategyFactory();
 
             IDataTypesConfigurationProvider dataTypesConfigurationProvider = new DataTypesConfigurationProvider(this.rulesEngineOptions);
+            IMultiplicityEvaluator multiplicityEvaluator = new MultiplicityEvaluator();
+            IConditionsTreeAnalyzer<TConditionType> conditionsTreeAnalyzer = new ConditionsTreeAnalyzer<TConditionType>();
 
-            IConditionEvalDispatchProvider conditionEvalDispatchProvider = new ConditionEvalDispatchProvider(operatorEvalStrategyFactory, dataTypesConfigurationProvider);
+            IConditionEvalDispatchProvider conditionEvalDispatchProvider = new ConditionEvalDispatchProvider(operatorEvalStrategyFactory, multiplicityEvaluator, dataTypesConfigurationProvider);
 
             IDeferredEval deferredEval = new DeferredEval(conditionEvalDispatchProvider, this.rulesEngineOptions);
 
-            IConditionsEvalEngine<TConditionType> conditionsEvalEngine = new ConditionsEvalEngine<TConditionType>(deferredEval);
+            IConditionsEvalEngine<TConditionType> conditionsEvalEngine = new ConditionsEvalEngine<TConditionType>(deferredEval, conditionsTreeAnalyzer);
 
             IConditionTypeExtractor<TContentType, TConditionType> conditionTypeExtractor = new ConditionTypeExtractor<TContentType, TConditionType>();
 

--- a/src/Rules.Framework/Builder/RuleBuilder.cs
+++ b/src/Rules.Framework/Builder/RuleBuilder.cs
@@ -6,7 +6,7 @@ namespace Rules.Framework.Builder
     using Rules.Framework.Builder.Validation;
     using Rules.Framework.Core;
 
-    internal class RuleBuilder<TContentType, TConditionType> : IRuleBuilder<TContentType, TConditionType>
+    internal sealed class RuleBuilder<TContentType, TConditionType> : IRuleBuilder<TContentType, TConditionType>
     {
         private ContentContainer<TContentType> contentContainer;
         private DateTime dateBegin;

--- a/src/Rules.Framework/Builder/RulesEngineOptionsValidator.cs
+++ b/src/Rules.Framework/Builder/RulesEngineOptionsValidator.cs
@@ -2,6 +2,7 @@ namespace Rules.Framework.Builder
 {
     using System;
     using System.Collections.Generic;
+    using System.Globalization;
     using Rules.Framework.Core;
 
     internal static class RulesEngineOptionsValidator
@@ -20,11 +21,11 @@ namespace Rules.Framework.Builder
             ValidateDataTypeDefault(
                 rulesEngineOptions.DataTypeDefaults,
                 DataTypes.Decimal,
-                value => value != null && decimal.TryParse(value.ToString(), out decimal decimalRes));
+                value => value != null && decimal.TryParse(value.ToString(), NumberStyles.None, CultureInfo.InvariantCulture, out decimal decimalRes));
             ValidateDataTypeDefault(
                 rulesEngineOptions.DataTypeDefaults,
                 DataTypes.Integer,
-                value => value != null && int.TryParse(value.ToString(), out int intRes));
+                value => value != null && int.TryParse(value.ToString(), NumberStyles.None, CultureInfo.InvariantCulture, out int intRes));
             ValidateDataTypeDefault(
                 rulesEngineOptions.DataTypeDefaults,
                 DataTypes.String,

--- a/src/Rules.Framework/Builder/RulesEngineSelectors.cs
+++ b/src/Rules.Framework/Builder/RulesEngineSelectors.cs
@@ -2,20 +2,20 @@ namespace Rules.Framework.Builder
 {
     using System;
 
-    internal class RulesEngineSelectors
+    internal static class RulesEngineSelectors
     {
-        internal class ConditionTypeSelector<TContentType> : IConditionTypeSelector<TContentType>
+        internal sealed class ConditionTypeSelector<TContentType> : IConditionTypeSelector<TContentType>
         {
             public IRulesDataSourceSelector<TContentType, TConditionType> WithConditionType<TConditionType>()
                 => new RulesDataSourceSelector<TContentType, TConditionType>();
         }
 
-        internal class ContentTypeSelector : IContentTypeSelector
+        internal sealed class ContentTypeSelector : IContentTypeSelector
         {
             public IConditionTypeSelector<TContentType> WithContentType<TContentType>() => new ConditionTypeSelector<TContentType>();
         }
 
-        internal class RulesDataSourceSelector<TContentType, TConditionType> : IRulesDataSourceSelector<TContentType, TConditionType>
+        internal sealed class RulesDataSourceSelector<TContentType, TConditionType> : IRulesDataSourceSelector<TContentType, TConditionType>
         {
             public IConfiguredRulesEngineBuilder<TContentType, TConditionType> SetDataSource(IRulesDataSource<TContentType, TConditionType> rulesDataSource)
             {

--- a/src/Rules.Framework/Builder/Validation/ComposedConditionNodeValidator.cs
+++ b/src/Rules.Framework/Builder/Validation/ComposedConditionNodeValidator.cs
@@ -4,7 +4,7 @@ namespace Rules.Framework.Builder.Validation
     using Rules.Framework.Core;
     using Rules.Framework.Core.ConditionNodes;
 
-    internal class ComposedConditionNodeValidator<TConditionType> : AbstractValidator<ComposedConditionNode<TConditionType>>
+    internal sealed class ComposedConditionNodeValidator<TConditionType> : AbstractValidator<ComposedConditionNode<TConditionType>>
     {
         private readonly ValueConditionNodeValidator<TConditionType> valueConditionNodeValidator;
 

--- a/src/Rules.Framework/Builder/Validation/ConditionNodeValidationArgs.cs
+++ b/src/Rules.Framework/Builder/Validation/ConditionNodeValidationArgs.cs
@@ -2,7 +2,7 @@ namespace Rules.Framework.Builder.Validation
 {
     using FluentValidation;
 
-    internal class ConditionNodeValidationArgs<TConditionType, TValidationContext>
+    internal sealed class ConditionNodeValidationArgs<TConditionType, TValidationContext>
     {
         public ComposedConditionNodeValidator<TConditionType> ComposedConditionNodeValidator { get; set; }
         public ValidationContext<TValidationContext> ValidationContext { get; set; }

--- a/src/Rules.Framework/Builder/Validation/RuleValidator.cs
+++ b/src/Rules.Framework/Builder/Validation/RuleValidator.cs
@@ -3,7 +3,7 @@ namespace Rules.Framework.Builder.Validation
     using FluentValidation;
     using Rules.Framework.Core;
 
-    internal class RuleValidator<TContentType, TConditionType> : AbstractValidator<Rule<TContentType, TConditionType>>
+    internal sealed class RuleValidator<TContentType, TConditionType> : AbstractValidator<Rule<TContentType, TConditionType>>
     {
         private readonly ComposedConditionNodeValidator<TConditionType> composedConditionNodeValidator;
         private readonly ValueConditionNodeValidator<TConditionType> valueConditionNodeValidator;

--- a/src/Rules.Framework/Builder/Validation/ValidationExtensions.cs
+++ b/src/Rules.Framework/Builder/Validation/ValidationExtensions.cs
@@ -1,19 +1,21 @@
-using System.Collections.Generic;
-using System.Linq;
-using FluentValidation;
-
 namespace Rules.Framework.Builder.Validation
 {
+    using System.Collections.Generic;
+    using System.Linq;
+    using FluentValidation;
+
     internal static class ValidationExtensions
     {
-        public static IRuleBuilderOptions<T, TProperty> IsContainedOn<T, TProperty>(this IRuleBuilderInitial<T, TProperty> ruleBuilderInitial, IEnumerable<TProperty> values)
+        public static IRuleBuilderOptions<T, TProperty> IsContainedOn<T, TProperty>(
+            this FluentValidation.IRuleBuilder<T, TProperty> ruleBuilder, IEnumerable<TProperty> values)
         {
-            return ruleBuilderInitial.Must((p) => values.Contains(p));
+            return ruleBuilder.Must((p) => values.Contains(p));
         }
 
-        public static IRuleBuilderOptions<T, TProperty> IsContainedOn<T, TProperty>(this IRuleBuilderInitial<T, TProperty> ruleBuilderInitial, params TProperty[] values)
+        public static IRuleBuilderOptions<T, TProperty> IsContainedOn<T, TProperty>(
+            this FluentValidation.IRuleBuilder<T, TProperty> ruleBuilder, params TProperty[] values)
         {
-            return ruleBuilderInitial.IsContainedOn((IEnumerable<TProperty>)values);
+            return ruleBuilder.IsContainedOn((IEnumerable<TProperty>)values);
         }
     }
 }

--- a/src/Rules.Framework/Builder/Validation/ValueConditionNodeValidator.cs
+++ b/src/Rules.Framework/Builder/Validation/ValueConditionNodeValidator.cs
@@ -5,24 +5,28 @@ namespace Rules.Framework.Builder.Validation
     using Rules.Framework.Core;
     using Rules.Framework.Core.ConditionNodes;
 
-    internal class ValueConditionNodeValidator<TConditionType> : AbstractValidator<ValueConditionNode<TConditionType>>
+    internal sealed class ValueConditionNodeValidator<TConditionType> : AbstractValidator<ValueConditionNode<TConditionType>>
     {
         public ValueConditionNodeValidator()
         {
-            this.RuleFor(c => c.ConditionType).NotEmpty();
-            this.RuleFor(c => c.ConditionType).IsInEnum().When(c => c.ConditionType is { } && c.ConditionType.GetType().IsEnum);
-            this.RuleFor(c => c.DataType).IsInEnum();
-            this.RuleFor(c => c.DataType).Equal(DataTypes.Integer).When(c => c.Operand is int);
-            this.RuleFor(c => c.DataType).Equal(DataTypes.String).When(c => c.Operand is string);
-            this.RuleFor(c => c.DataType).Equal(DataTypes.Decimal).When(c => c.Operand is decimal);
-            this.RuleFor(c => c.DataType).Equal(DataTypes.Boolean).When(c => c.Operand is bool);
+            this.RuleFor(c => c.ConditionType)
+                .NotEmpty()
+                .IsInEnum()
+                .When(c => c.ConditionType.GetType().IsEnum);
 
-            this.RuleFor(c => c.DataType).Equal(DataTypes.ArrayInteger).When(c => c.Operand is IEnumerable<int>);
-            this.RuleFor(c => c.DataType).Equal(DataTypes.ArrayString).When(c => c.Operand is IEnumerable<string>);
-            this.RuleFor(c => c.DataType).Equal(DataTypes.ArrayDecimal).When(c => c.Operand is IEnumerable<decimal>);
-            this.RuleFor(c => c.DataType).Equal(DataTypes.ArrayBoolean).When(c => c.Operand is IEnumerable<bool>);
+            this.RuleFor(c => c.DataType)
+                .IsInEnum()
+                .Equal(DataTypes.Integer).When(c => c.Operand is int)
+                .Equal(DataTypes.String).When(c => c.Operand is string)
+                .Equal(DataTypes.Decimal).When(c => c.Operand is decimal)
+                .Equal(DataTypes.Boolean).When(c => c.Operand is bool)
+                .Equal(DataTypes.ArrayInteger).When(c => c.Operand is IEnumerable<int>)
+                .Equal(DataTypes.ArrayString).When(c => c.Operand is IEnumerable<string>)
+                .Equal(DataTypes.ArrayDecimal).When(c => c.Operand is IEnumerable<decimal>)
+                .Equal(DataTypes.ArrayBoolean).When(c => c.Operand is IEnumerable<bool>);
 
-            this.RuleFor(c => c.Operator).IsInEnum();
+            this.RuleFor(c => c.Operator)
+                .IsInEnum();
 
             this.RuleFor(c => c.Operator)
                 .IsContainedOn(Operators.Equal, Operators.NotEqual, Operators.Contains, Operators.NotContains, Operators.StartsWith, Operators.EndsWith, Operators.CaseInsensitiveStartsWith, Operators.CaseInsensitiveEndsWith, Operators.NotStartsWith, Operators.NotEndsWith)

--- a/src/Rules.Framework/Builder/ValueConditionNodeBuilder.cs
+++ b/src/Rules.Framework/Builder/ValueConditionNodeBuilder.cs
@@ -5,7 +5,7 @@ namespace Rules.Framework.Builder
     using Rules.Framework.Core;
     using Rules.Framework.Core.ConditionNodes;
 
-    internal class ValueConditionNodeBuilder<TConditionType> : IValueConditionNodeBuilder<TConditionType>
+    internal sealed class ValueConditionNodeBuilder<TConditionType> : IValueConditionNodeBuilder<TConditionType>
     {
         private readonly TConditionType conditionType;
 
@@ -18,7 +18,7 @@ namespace Rules.Framework.Builder
             => new ValueConditionNodeBuilder<TConditionType, T>(this.conditionType);
     }
 
-    internal class ValueConditionNodeBuilder<TConditionType, TDataType> : IValueConditionNodeBuilder<TConditionType, TDataType>
+    internal sealed class ValueConditionNodeBuilder<TConditionType, TDataType> : IValueConditionNodeBuilder<TConditionType, TDataType>
     {
         private readonly TConditionType conditionType;
         private Operators comparisonOperator;

--- a/src/Rules.Framework/ConditionTypeExtractor.cs
+++ b/src/Rules.Framework/ConditionTypeExtractor.cs
@@ -36,10 +36,8 @@ namespace Rules.Framework
                 return conditionTypes;
             }
 
-            foreach (var rule in matchedRules)
+            foreach (var rootCondition in matchedRules.Select(r => r.RootCondition))
             {
-                var rootCondition = rule.RootCondition;
-
                 if (rootCondition is null)
                 {
                     continue;

--- a/src/Rules.Framework/Evaluation/ConditionsTreeAnalyzer.cs
+++ b/src/Rules.Framework/Evaluation/ConditionsTreeAnalyzer.cs
@@ -1,0 +1,49 @@
+namespace Rules.Framework.Evaluation
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using Rules.Framework.Core;
+    using Rules.Framework.Core.ConditionNodes;
+
+    internal sealed class ConditionsTreeAnalyzer<TConditionType> : IConditionsTreeAnalyzer<TConditionType>
+    {
+        public bool AreAllSearchConditionsPresent(IConditionNode<TConditionType> conditionNode, IDictionary<TConditionType, object> conditions)
+        {
+            // Conditions checklist is a mere control construct to avoid a full sweep of the
+            // condition nodes tree when we already found all conditions.
+            var conditionsChecklist = new Dictionary<TConditionType, bool>(conditions.ToDictionary(ks => ks.Key, vs => false));
+
+            return VisitConditionNode(conditionNode, conditionsChecklist);
+        }
+
+        private static bool VisitConditionNode(IConditionNode<TConditionType> conditionNode, IDictionary<TConditionType, bool> conditionsChecklist)
+        {
+            switch (conditionNode)
+            {
+                case IValueConditionNode<TConditionType> valueConditionNode:
+                    if (conditionsChecklist.ContainsKey(valueConditionNode.ConditionType))
+                    {
+                        conditionsChecklist[valueConditionNode.ConditionType] = true;
+                    }
+
+                    return conditionsChecklist.All(kvp => kvp.Value);
+
+                case ComposedConditionNode<TConditionType> composedConditionNode:
+                    foreach (var childConditionNode in composedConditionNode.ChildConditionNodes)
+                    {
+                        var allPresentAlready = VisitConditionNode(childConditionNode, conditionsChecklist);
+                        if (allPresentAlready)
+                        {
+                            return true;
+                        }
+                    }
+
+                    return false;
+
+                default:
+                    throw new NotSupportedException($"Unsupported condition node: '{conditionNode.GetType().Name}'.");
+            }
+        }
+    }
+}

--- a/src/Rules.Framework/Evaluation/EvaluationOptions.cs
+++ b/src/Rules.Framework/Evaluation/EvaluationOptions.cs
@@ -1,7 +1,9 @@
 namespace Rules.Framework.Evaluation
 {
     using System;
+    using System.Runtime.InteropServices;
 
+    [StructLayout(LayoutKind.Auto)]
     internal struct EvaluationOptions : IEquatable<EvaluationOptions>
     {
         public bool ExcludeRulesWithoutSearchConditions { get; set; }

--- a/src/Rules.Framework/Evaluation/IConditionsEvalEngine.cs
+++ b/src/Rules.Framework/Evaluation/IConditionsEvalEngine.cs
@@ -5,6 +5,6 @@ namespace Rules.Framework.Evaluation
 
     internal interface IConditionsEvalEngine<TConditionType>
     {
-        bool Eval(IConditionNode<TConditionType> conditionNode, IEnumerable<Condition<TConditionType>> conditions, EvaluationOptions evaluationOptions);
+        bool Eval(IConditionNode<TConditionType> conditionNode, IDictionary<TConditionType, object> conditions, EvaluationOptions evaluationOptions);
     }
 }

--- a/src/Rules.Framework/Evaluation/IConditionsTreeAnalyzer.cs
+++ b/src/Rules.Framework/Evaluation/IConditionsTreeAnalyzer.cs
@@ -1,0 +1,10 @@
+namespace Rules.Framework.Evaluation
+{
+    using System.Collections.Generic;
+    using Rules.Framework.Core;
+
+    internal interface IConditionsTreeAnalyzer<TConditionType>
+    {
+        bool AreAllSearchConditionsPresent(IConditionNode<TConditionType> conditionNode, IDictionary<TConditionType, object> conditions);
+    }
+}

--- a/src/Rules.Framework/Evaluation/IMultiplicityEvaluator.cs
+++ b/src/Rules.Framework/Evaluation/IMultiplicityEvaluator.cs
@@ -1,0 +1,9 @@
+namespace Rules.Framework.Evaluation
+{
+    using Rules.Framework.Core;
+
+    internal interface IMultiplicityEvaluator
+    {
+        string EvaluateMultiplicity(object leftOperand, Operators @operator, object rightOperand);
+    }
+}

--- a/src/Rules.Framework/Evaluation/MatchModes.cs
+++ b/src/Rules.Framework/Evaluation/MatchModes.cs
@@ -1,6 +1,6 @@
 namespace Rules.Framework.Evaluation
 {
-    internal enum MatchModes
+    internal enum MatchModes : byte
     {
         Exact = 1,
         Search = 2

--- a/src/Rules.Framework/Evaluation/Multiplicities.cs
+++ b/src/Rules.Framework/Evaluation/Multiplicities.cs
@@ -1,0 +1,10 @@
+namespace Rules.Framework.Evaluation
+{
+    internal static class Multiplicities
+    {
+        public const string ManyToMany = "many-to-many";
+        public const string ManyToOne = "many-to-one";
+        public const string OneToMany = "one-to-many";
+        public const string OneToOne = "one-to-one";
+    }
+}

--- a/src/Rules.Framework/Evaluation/OperatorMetadata.cs
+++ b/src/Rules.Framework/Evaluation/OperatorMetadata.cs
@@ -1,0 +1,30 @@
+namespace Rules.Framework.Evaluation
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using Rules.Framework.Core;
+
+    internal sealed class OperatorMetadata
+    {
+        private bool? leftSupportForOneMultiplicity = null;
+
+        public bool HasSupportForOneMultiplicityAtLeft
+        {
+            get
+            {
+                if (this.leftSupportForOneMultiplicity is null)
+                {
+                    this.leftSupportForOneMultiplicity = this.SupportedMultiplicities?.Any(m => m.Contains("one-to")) ?? false;
+                }
+
+                return this.leftSupportForOneMultiplicity.GetValueOrDefault();
+            }
+        }
+
+        public Operators Operator { get; set; }
+
+        public string[] SupportedMultiplicities { get; set; }
+
+        public IEnumerable<string> GetAllCombinations() => this.SupportedMultiplicities.Select(x => $"{x}-{this.Operator}");
+    }
+}

--- a/src/Rules.Framework/Evaluation/OperatorsMetadata.cs
+++ b/src/Rules.Framework/Evaluation/OperatorsMetadata.cs
@@ -1,0 +1,153 @@
+namespace Rules.Framework.Evaluation
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Collections.ObjectModel;
+    using System.Linq;
+    using Rules.Framework.Core;
+
+    internal static class OperatorsMetadata
+    {
+        private static readonly IDictionary<Operators, OperatorMetadata> allOperatorsMetadata;
+
+        private static readonly IDictionary<string, OperatorMetadata> allOperatorsMetadataBySupportedCombination;
+
+        private static readonly IEnumerable<OperatorMetadata> operatorsMetadata = new[]
+                        {
+            OperatorsMetadata.Equal,
+            OperatorsMetadata.NotEqual,
+            OperatorsMetadata.GreaterThan,
+            OperatorsMetadata.GreaterThanOrEqual,
+            OperatorsMetadata.LesserThan,
+            OperatorsMetadata.LesserThanOrEqual,
+            OperatorsMetadata.Contains,
+            OperatorsMetadata.NotContains,
+            OperatorsMetadata.In,
+            OperatorsMetadata.StartsWith,
+            OperatorsMetadata.EndsWith,
+            OperatorsMetadata.CaseInsensitiveStartsWith,
+            OperatorsMetadata.CaseInsensitiveEndsWith,
+            OperatorsMetadata.NotStartsWith,
+            OperatorsMetadata.NotEndsWith,
+        };
+
+        static OperatorsMetadata()
+        {
+            allOperatorsMetadata = new Dictionary<Operators, OperatorMetadata>();
+            var allOperatorsMetadataBySupportedCombinationAux = new Dictionary<string, OperatorMetadata>(StringComparer.Ordinal);
+
+            foreach (var operatorMetadata in operatorsMetadata)
+            {
+                allOperatorsMetadata.Add(operatorMetadata.Operator, operatorMetadata);
+
+                var supportedCombinations = operatorMetadata.GetAllCombinations();
+
+                foreach (var combination in supportedCombinations)
+                {
+                    allOperatorsMetadataBySupportedCombinationAux.Add(combination, operatorMetadata);
+                }
+            }
+
+            allOperatorsMetadataBySupportedCombination
+                = new ReadOnlyDictionary<string, OperatorMetadata>(allOperatorsMetadataBySupportedCombinationAux);
+        }
+
+        public static IEnumerable<OperatorMetadata> All => allOperatorsMetadata.Values;
+
+        public static IDictionary<Operators, OperatorMetadata> AllByOperator => allOperatorsMetadata;
+
+        public static IDictionary<string, OperatorMetadata> AllBySupportedCombination => allOperatorsMetadataBySupportedCombination;
+
+        public static IEnumerable<string> AllSupportedCombinations => All.SelectMany(x => x.GetAllCombinations());
+
+        public static OperatorMetadata CaseInsensitiveEndsWith => new()
+        {
+            Operator = Operators.CaseInsensitiveEndsWith,
+            SupportedMultiplicities = new[] { Multiplicities.OneToOne },
+        };
+
+        public static OperatorMetadata CaseInsensitiveStartsWith => new()
+        {
+            Operator = Operators.CaseInsensitiveStartsWith,
+            SupportedMultiplicities = new[] { Multiplicities.OneToOne },
+        };
+
+        public static OperatorMetadata Contains => new()
+        {
+            Operator = Operators.Contains,
+            SupportedMultiplicities = new[] { Multiplicities.OneToOne },
+        };
+
+        public static OperatorMetadata EndsWith => new()
+        {
+            Operator = Operators.EndsWith,
+            SupportedMultiplicities = new[] { Multiplicities.OneToOne },
+        };
+
+        public static OperatorMetadata Equal => new()
+        {
+            Operator = Operators.Equal,
+            SupportedMultiplicities = new[] { Multiplicities.OneToOne },
+        };
+
+        public static OperatorMetadata GreaterThan => new()
+        {
+            Operator = Operators.GreaterThan,
+            SupportedMultiplicities = new[] { Multiplicities.OneToOne },
+        };
+
+        public static OperatorMetadata GreaterThanOrEqual => new()
+        {
+            Operator = Operators.GreaterThanOrEqual,
+            SupportedMultiplicities = new[] { Multiplicities.OneToOne },
+        };
+
+        public static OperatorMetadata In => new()
+        {
+            Operator = Operators.In,
+            SupportedMultiplicities = new[] { Multiplicities.OneToMany },
+        };
+
+        public static OperatorMetadata LesserThan => new()
+        {
+            Operator = Operators.LesserThan,
+            SupportedMultiplicities = new[] { Multiplicities.OneToOne },
+        };
+
+        public static OperatorMetadata LesserThanOrEqual => new()
+        {
+            Operator = Operators.LesserThanOrEqual,
+            SupportedMultiplicities = new[] { Multiplicities.OneToOne },
+        };
+
+        public static OperatorMetadata NotContains => new()
+        {
+            Operator = Operators.NotContains,
+            SupportedMultiplicities = new[] { Multiplicities.OneToOne },
+        };
+
+        public static OperatorMetadata NotEndsWith => new()
+        {
+            Operator = Operators.NotEndsWith,
+            SupportedMultiplicities = new[] { Multiplicities.OneToOne },
+        };
+
+        public static OperatorMetadata NotEqual => new()
+        {
+            Operator = Operators.NotEqual,
+            SupportedMultiplicities = new[] { Multiplicities.OneToOne },
+        };
+
+        public static OperatorMetadata NotStartsWith => new()
+        {
+            Operator = Operators.NotStartsWith,
+            SupportedMultiplicities = new[] { Multiplicities.OneToOne },
+        };
+
+        public static OperatorMetadata StartsWith => new()
+        {
+            Operator = Operators.StartsWith,
+            SupportedMultiplicities = new[] { Multiplicities.OneToOne },
+        };
+    }
+}

--- a/src/Rules.Framework/Evaluation/OperatorsMetadata.cs
+++ b/src/Rules.Framework/Evaluation/OperatorsMetadata.cs
@@ -13,7 +13,7 @@ namespace Rules.Framework.Evaluation
         private static readonly IDictionary<string, OperatorMetadata> allOperatorsMetadataBySupportedCombination;
 
         private static readonly IEnumerable<OperatorMetadata> operatorsMetadata = new[]
-                        {
+        {
             OperatorsMetadata.Equal,
             OperatorsMetadata.NotEqual,
             OperatorsMetadata.GreaterThan,

--- a/src/Rules.Framework/Evaluation/Specification/AndSpecification.cs
+++ b/src/Rules.Framework/Evaluation/Specification/AndSpecification.cs
@@ -1,6 +1,6 @@
 namespace Rules.Framework.Evaluation.Specification
 {
-    internal class AndSpecification<T> : SpecificationBase<T>
+    internal sealed class AndSpecification<T> : SpecificationBase<T>
     {
         private readonly ISpecification<T> leftSpecification;
 

--- a/src/Rules.Framework/Evaluation/Specification/FuncSpecification.cs
+++ b/src/Rules.Framework/Evaluation/Specification/FuncSpecification.cs
@@ -2,7 +2,7 @@ namespace Rules.Framework.Evaluation.Specification
 {
     using System;
 
-    internal class FuncSpecification<T> : SpecificationBase<T>
+    internal sealed class FuncSpecification<T> : SpecificationBase<T>
     {
         private readonly Func<T, bool> evalFunc;
 

--- a/src/Rules.Framework/Evaluation/Specification/OrSpecification.cs
+++ b/src/Rules.Framework/Evaluation/Specification/OrSpecification.cs
@@ -1,6 +1,6 @@
 namespace Rules.Framework.Evaluation.Specification
 {
-    internal class OrSpecification<T> : SpecificationBase<T>
+    internal sealed class OrSpecification<T> : SpecificationBase<T>
     {
         private readonly ISpecification<T> leftSpecification;
 

--- a/src/Rules.Framework/Evaluation/ValueEvaluation/CaseInsensitiveEndsWithOperatorEvalStrategy.cs
+++ b/src/Rules.Framework/Evaluation/ValueEvaluation/CaseInsensitiveEndsWithOperatorEvalStrategy.cs
@@ -3,7 +3,7 @@ namespace Rules.Framework.Evaluation.ValueEvaluation
     using System;
     using System.Globalization;
 
-    internal class CaseInsensitiveEndsWithOperatorEvalStrategy : IOneToOneOperatorEvalStrategy
+    internal sealed class CaseInsensitiveEndsWithOperatorEvalStrategy : IOneToOneOperatorEvalStrategy
     {
         public bool Eval(object leftOperand, object rightOperand)
         {

--- a/src/Rules.Framework/Evaluation/ValueEvaluation/CaseInsensitiveStartsWithOperatorEvalStrategy.cs
+++ b/src/Rules.Framework/Evaluation/ValueEvaluation/CaseInsensitiveStartsWithOperatorEvalStrategy.cs
@@ -3,7 +3,7 @@ namespace Rules.Framework.Evaluation.ValueEvaluation
     using System;
     using System.Globalization;
 
-    internal class CaseInsensitiveStartsWithOperatorEvalStrategy : IOneToOneOperatorEvalStrategy
+    internal sealed class CaseInsensitiveStartsWithOperatorEvalStrategy : IOneToOneOperatorEvalStrategy
     {
         public bool Eval(object leftOperand, object rightOperand)
         {

--- a/src/Rules.Framework/Evaluation/ValueEvaluation/ContainsOperatorEvalStrategy.cs
+++ b/src/Rules.Framework/Evaluation/ValueEvaluation/ContainsOperatorEvalStrategy.cs
@@ -2,7 +2,7 @@ namespace Rules.Framework.Evaluation.ValueEvaluation
 {
     using System;
 
-    internal class ContainsOperatorEvalStrategy : IOneToOneOperatorEvalStrategy
+    internal sealed class ContainsOperatorEvalStrategy : IOneToOneOperatorEvalStrategy
     {
         public bool Eval(object leftOperand, object rightOperand)
         {

--- a/src/Rules.Framework/Evaluation/ValueEvaluation/Dispatchers/DataTypeConfiguration.cs
+++ b/src/Rules.Framework/Evaluation/ValueEvaluation/Dispatchers/DataTypeConfiguration.cs
@@ -3,7 +3,7 @@ namespace Rules.Framework.Evaluation.ValueEvaluation.Dispatchers
     using System;
     using Rules.Framework.Core;
 
-    internal class DataTypeConfiguration
+    internal sealed class DataTypeConfiguration
     {
         private DataTypeConfiguration()
         {

--- a/src/Rules.Framework/Evaluation/ValueEvaluation/Dispatchers/DataTypesConfigurationProvider.cs
+++ b/src/Rules.Framework/Evaluation/ValueEvaluation/Dispatchers/DataTypesConfigurationProvider.cs
@@ -4,7 +4,7 @@ namespace Rules.Framework.Evaluation.ValueEvaluation.Dispatchers
     using System.Collections.Generic;
     using Rules.Framework.Core;
 
-    internal class DataTypesConfigurationProvider : IDataTypesConfigurationProvider
+    internal sealed class DataTypesConfigurationProvider : IDataTypesConfigurationProvider
     {
         private readonly IDictionary<DataTypes, DataTypeConfiguration> dataTypeConfigurations;
 

--- a/src/Rules.Framework/Evaluation/ValueEvaluation/Dispatchers/ManyToManyConditionEvalDispatcher.cs
+++ b/src/Rules.Framework/Evaluation/ValueEvaluation/Dispatchers/ManyToManyConditionEvalDispatcher.cs
@@ -4,7 +4,7 @@ namespace Rules.Framework.Evaluation.ValueEvaluation.Dispatchers
     using System.Linq;
     using Rules.Framework.Core;
 
-    internal class ManyToManyConditionEvalDispatcher : ConditionEvalDispatcherBase, IConditionEvalDispatcher
+    internal sealed class ManyToManyConditionEvalDispatcher : ConditionEvalDispatcherBase, IConditionEvalDispatcher
     {
         private readonly IOperatorEvalStrategyFactory operatorEvalStrategyFactory;
 

--- a/src/Rules.Framework/Evaluation/ValueEvaluation/Dispatchers/ManyToOneConditionEvalDispatcher.cs
+++ b/src/Rules.Framework/Evaluation/ValueEvaluation/Dispatchers/ManyToOneConditionEvalDispatcher.cs
@@ -4,7 +4,7 @@ namespace Rules.Framework.Evaluation.ValueEvaluation.Dispatchers
     using System.Linq;
     using Rules.Framework.Core;
 
-    internal class ManyToOneConditionEvalDispatcher : ConditionEvalDispatcherBase, IConditionEvalDispatcher
+    internal sealed class ManyToOneConditionEvalDispatcher : ConditionEvalDispatcherBase, IConditionEvalDispatcher
     {
         private readonly IOperatorEvalStrategyFactory operatorEvalStrategyFactory;
 

--- a/src/Rules.Framework/Evaluation/ValueEvaluation/Dispatchers/OneToManyConditionEvalDispatcher.cs
+++ b/src/Rules.Framework/Evaluation/ValueEvaluation/Dispatchers/OneToManyConditionEvalDispatcher.cs
@@ -4,7 +4,7 @@ namespace Rules.Framework.Evaluation.ValueEvaluation.Dispatchers
     using System.Linq;
     using Rules.Framework.Core;
 
-    internal class OneToManyConditionEvalDispatcher : ConditionEvalDispatcherBase, IConditionEvalDispatcher
+    internal sealed class OneToManyConditionEvalDispatcher : ConditionEvalDispatcherBase, IConditionEvalDispatcher
     {
         private readonly IOperatorEvalStrategyFactory operatorEvalStrategyFactory;
 

--- a/src/Rules.Framework/Evaluation/ValueEvaluation/Dispatchers/OneToOneConditionEvalDispatcher.cs
+++ b/src/Rules.Framework/Evaluation/ValueEvaluation/Dispatchers/OneToOneConditionEvalDispatcher.cs
@@ -2,7 +2,7 @@ namespace Rules.Framework.Evaluation.ValueEvaluation.Dispatchers
 {
     using Rules.Framework.Core;
 
-    internal class OneToOneConditionEvalDispatcher : ConditionEvalDispatcherBase, IConditionEvalDispatcher
+    internal sealed class OneToOneConditionEvalDispatcher : ConditionEvalDispatcherBase, IConditionEvalDispatcher
     {
         private readonly IOperatorEvalStrategyFactory operatorEvalStrategyFactory;
 

--- a/src/Rules.Framework/Evaluation/ValueEvaluation/EndsWithOperatorEvalStrategy.cs
+++ b/src/Rules.Framework/Evaluation/ValueEvaluation/EndsWithOperatorEvalStrategy.cs
@@ -2,7 +2,7 @@ namespace Rules.Framework.Evaluation.ValueEvaluation
 {
     using System;
 
-    internal class EndsWithOperatorEvalStrategy : IOneToOneOperatorEvalStrategy
+    internal sealed class EndsWithOperatorEvalStrategy : IOneToOneOperatorEvalStrategy
     {
         public bool Eval(object leftOperand, object rightOperand)
         {
@@ -11,7 +11,7 @@ namespace Rules.Framework.Evaluation.ValueEvaluation
                 string leftOperandAsString = leftOperand as string;
                 string rightOperandAsString = rightOperand as string;
 
-                return leftOperandAsString.EndsWith(rightOperandAsString);
+                return leftOperandAsString.EndsWith(rightOperandAsString, StringComparison.Ordinal);
             }
 
             throw new NotSupportedException($"Unsupported 'endswith' comparison between operands of type '{leftOperand?.GetType().FullName}' and '{rightOperand?.GetType().FullName}'.");

--- a/src/Rules.Framework/Evaluation/ValueEvaluation/EqualOperatorEvalStrategy.cs
+++ b/src/Rules.Framework/Evaluation/ValueEvaluation/EqualOperatorEvalStrategy.cs
@@ -2,7 +2,7 @@ namespace Rules.Framework.Evaluation.ValueEvaluation
 {
     using System;
 
-    internal class EqualOperatorEvalStrategy : IOneToOneOperatorEvalStrategy
+    internal sealed class EqualOperatorEvalStrategy : IOneToOneOperatorEvalStrategy
     {
         public bool Eval(object leftOperand, object rightOperand)
         {

--- a/src/Rules.Framework/Evaluation/ValueEvaluation/GreaterThanOperatorEvalStrategy.cs
+++ b/src/Rules.Framework/Evaluation/ValueEvaluation/GreaterThanOperatorEvalStrategy.cs
@@ -2,7 +2,7 @@ namespace Rules.Framework.Evaluation.ValueEvaluation
 {
     using System;
 
-    internal class GreaterThanOperatorEvalStrategy : IOneToOneOperatorEvalStrategy
+    internal sealed class GreaterThanOperatorEvalStrategy : IOneToOneOperatorEvalStrategy
     {
         public bool Eval(object leftOperand, object rightOperand)
         {

--- a/src/Rules.Framework/Evaluation/ValueEvaluation/GreaterThanOrEqualOperatorEvalStrategy.cs
+++ b/src/Rules.Framework/Evaluation/ValueEvaluation/GreaterThanOrEqualOperatorEvalStrategy.cs
@@ -2,7 +2,7 @@ namespace Rules.Framework.Evaluation.ValueEvaluation
 {
     using System;
 
-    internal class GreaterThanOrEqualOperatorEvalStrategy : IOneToOneOperatorEvalStrategy
+    internal sealed class GreaterThanOrEqualOperatorEvalStrategy : IOneToOneOperatorEvalStrategy
     {
         public bool Eval(object leftOperand, object rightOperand)
         {

--- a/src/Rules.Framework/Evaluation/ValueEvaluation/IDeferredEval.cs
+++ b/src/Rules.Framework/Evaluation/ValueEvaluation/IDeferredEval.cs
@@ -6,6 +6,6 @@ namespace Rules.Framework.Evaluation.ValueEvaluation
 
     internal interface IDeferredEval
     {
-        Func<IEnumerable<Condition<TConditionType>>, bool> GetDeferredEvalFor<TConditionType>(IValueConditionNode<TConditionType> valueConditionNode, MatchModes matchMode);
+        Func<IDictionary<TConditionType, object>, bool> GetDeferredEvalFor<TConditionType>(IValueConditionNode<TConditionType> valueConditionNode, MatchModes matchMode);
     }
 }

--- a/src/Rules.Framework/Evaluation/ValueEvaluation/InOperatorEvalStrategy.cs
+++ b/src/Rules.Framework/Evaluation/ValueEvaluation/InOperatorEvalStrategy.cs
@@ -3,7 +3,7 @@ namespace Rules.Framework.Evaluation.ValueEvaluation
     using System.Collections.Generic;
     using System.Linq;
 
-    internal class InOperatorEvalStrategy : IOneToManyOperatorEvalStrategy
+    internal sealed class InOperatorEvalStrategy : IOneToManyOperatorEvalStrategy
     {
         public bool Eval(object leftOperand, IEnumerable<object> rightOperand)
             => rightOperand.Contains(leftOperand);

--- a/src/Rules.Framework/Evaluation/ValueEvaluation/LesserThanOperatorEvalStrategy.cs
+++ b/src/Rules.Framework/Evaluation/ValueEvaluation/LesserThanOperatorEvalStrategy.cs
@@ -2,7 +2,7 @@ namespace Rules.Framework.Evaluation.ValueEvaluation
 {
     using System;
 
-    internal class LesserThanOperatorEvalStrategy : IOneToOneOperatorEvalStrategy
+    internal sealed class LesserThanOperatorEvalStrategy : IOneToOneOperatorEvalStrategy
     {
         public bool Eval(object leftOperand, object rightOperand)
         {

--- a/src/Rules.Framework/Evaluation/ValueEvaluation/LesserThanOrEqualOperatorEvalStrategy.cs
+++ b/src/Rules.Framework/Evaluation/ValueEvaluation/LesserThanOrEqualOperatorEvalStrategy.cs
@@ -2,7 +2,7 @@ namespace Rules.Framework.Evaluation.ValueEvaluation
 {
     using System;
 
-    internal class LesserThanOrEqualOperatorEvalStrategy : IOneToOneOperatorEvalStrategy
+    internal sealed class LesserThanOrEqualOperatorEvalStrategy : IOneToOneOperatorEvalStrategy
     {
         public bool Eval(object leftOperand, object rightOperand)
         {

--- a/src/Rules.Framework/Evaluation/ValueEvaluation/NotContainsOperatorEvalStrategy.cs
+++ b/src/Rules.Framework/Evaluation/ValueEvaluation/NotContainsOperatorEvalStrategy.cs
@@ -2,7 +2,7 @@ namespace Rules.Framework.Evaluation.ValueEvaluation
 {
     using System;
 
-    internal class NotContainsOperatorEvalStrategy : IOneToOneOperatorEvalStrategy
+    internal sealed class NotContainsOperatorEvalStrategy : IOneToOneOperatorEvalStrategy
     {
         public bool Eval(object leftOperand, object rightOperand)
         {

--- a/src/Rules.Framework/Evaluation/ValueEvaluation/NotEndsWithOperatorEvalStrategy.cs
+++ b/src/Rules.Framework/Evaluation/ValueEvaluation/NotEndsWithOperatorEvalStrategy.cs
@@ -2,7 +2,7 @@ namespace Rules.Framework.Evaluation.ValueEvaluation
 {
     using System;
 
-    internal class NotEndsWithOperatorEvalStrategy : IOneToOneOperatorEvalStrategy
+    internal sealed class NotEndsWithOperatorEvalStrategy : IOneToOneOperatorEvalStrategy
     {
         public bool Eval(object leftOperand, object rightOperand)
         {
@@ -11,7 +11,7 @@ namespace Rules.Framework.Evaluation.ValueEvaluation
                 var leftOperandAsString = leftOperand as string;
                 var rightOperandAsString = rightOperand as string;
 
-                return !leftOperandAsString.EndsWith(rightOperandAsString);
+                return !leftOperandAsString.EndsWith(rightOperandAsString, StringComparison.Ordinal);
             }
 
             throw new NotSupportedException($"Only operands of type {nameof(String)} supported.");

--- a/src/Rules.Framework/Evaluation/ValueEvaluation/NotEqualOperatorEvalStrategy.cs
+++ b/src/Rules.Framework/Evaluation/ValueEvaluation/NotEqualOperatorEvalStrategy.cs
@@ -2,7 +2,7 @@ namespace Rules.Framework.Evaluation.ValueEvaluation
 {
     using System;
 
-    internal class NotEqualOperatorEvalStrategy : IOneToOneOperatorEvalStrategy
+    internal sealed class NotEqualOperatorEvalStrategy : IOneToOneOperatorEvalStrategy
     {
         public bool Eval(object leftOperand, object rightOperand)
         {

--- a/src/Rules.Framework/Evaluation/ValueEvaluation/NotStartsWithOperatorEvalStrategy.cs
+++ b/src/Rules.Framework/Evaluation/ValueEvaluation/NotStartsWithOperatorEvalStrategy.cs
@@ -2,7 +2,7 @@ namespace Rules.Framework.Evaluation.ValueEvaluation
 {
     using System;
 
-    internal class NotStartsWithOperatorEvalStrategy : IOneToOneOperatorEvalStrategy
+    internal sealed class NotStartsWithOperatorEvalStrategy : IOneToOneOperatorEvalStrategy
     {
         public bool Eval(object leftOperand, object rightOperand)
         {
@@ -11,7 +11,7 @@ namespace Rules.Framework.Evaluation.ValueEvaluation
                 var leftOperandAsString = leftOperand as string;
                 var rightOperandAsString = rightOperand as string;
 
-                return !leftOperandAsString.StartsWith(rightOperandAsString);
+                return !leftOperandAsString.StartsWith(rightOperandAsString, StringComparison.Ordinal);
             }
 
             throw new NotSupportedException($"Only operands of type {nameof(String)} supported.");

--- a/src/Rules.Framework/Evaluation/ValueEvaluation/OperatorEvalStrategyFactory.cs
+++ b/src/Rules.Framework/Evaluation/ValueEvaluation/OperatorEvalStrategyFactory.cs
@@ -4,7 +4,7 @@ namespace Rules.Framework.Evaluation.ValueEvaluation
     using System.Collections.Generic;
     using Rules.Framework.Core;
 
-    internal class OperatorEvalStrategyFactory : IOperatorEvalStrategyFactory
+    internal sealed class OperatorEvalStrategyFactory : IOperatorEvalStrategyFactory
     {
         private readonly IDictionary<Operators, object> strategies;
 

--- a/src/Rules.Framework/Evaluation/ValueEvaluation/StartsWithOperatorEvalStrategy.cs
+++ b/src/Rules.Framework/Evaluation/ValueEvaluation/StartsWithOperatorEvalStrategy.cs
@@ -2,7 +2,7 @@ namespace Rules.Framework.Evaluation.ValueEvaluation
 {
     using System;
 
-    internal class StartsWithOperatorEvalStrategy : IOneToOneOperatorEvalStrategy
+    internal sealed class StartsWithOperatorEvalStrategy : IOneToOneOperatorEvalStrategy
     {
         public bool Eval(object leftOperand, object rightOperand)
         {
@@ -11,7 +11,7 @@ namespace Rules.Framework.Evaluation.ValueEvaluation
                 string leftOperandAsString = leftOperand as string;
                 string rightOperandAsString = rightOperand as string;
 
-                return leftOperandAsString.StartsWith(rightOperandAsString);
+                return leftOperandAsString.StartsWith(rightOperandAsString, StringComparison.Ordinal);
             }
 
             throw new NotSupportedException($"Unsupported 'startswith' comparison between operands of type '{leftOperand?.GetType().FullName}' and '{rightOperand?.GetType().FullName}'.");

--- a/src/Rules.Framework/GlobalSuppressions.cs
+++ b/src/Rules.Framework/GlobalSuppressions.cs
@@ -1,7 +1,6 @@
-// This file is used by Code Analysis to maintain SuppressMessage
-// attributes that are applied to this project.
-// Project-level suppressions either have no target or are given
-// a specific target and scoped to a namespace, type, member, etc.
+// This file is used by Code Analysis to maintain SuppressMessage attributes that are applied to
+// this project. Project-level suppressions either have no target or are given a specific target and
+// scoped to a namespace, type, member, etc.
 
 using System.Diagnostics.CodeAnalysis;
 
@@ -17,3 +16,4 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage("Design", "CA1062:Validate arguments of public methods", Justification = "<Pending>", Scope = "member", Target = "~M:Rules.Framework.RulesEngine`2.AddRuleAsync(Rules.Framework.Core.Rule{`0,`1})~System.Threading.Tasks.Task")]
 [assembly: SuppressMessage("Naming", "CA1717:Only FlagsAttribute enums should have plural names", Justification = "<Pending>", Scope = "type", Target = "~T:Rules.Framework.PriorityOptions")]
 [assembly: SuppressMessage("Major Bug", "S2259:Null pointers should not be dereferenced", Justification = "That is validated somes lines above, and if it is null, a RuleOperationResult with error is returned right away.", Scope = "member", Target = "~M:Rules.Framework.RulesEngine`2.UpdateRuleInternalAsync(Rules.Framework.Core.Rule{`0,`1})~System.Threading.Tasks.Task{Rules.Framework.RuleOperationResult}")]
+[assembly: SuppressMessage("Minor Code Smell", "S3963:\"static\" fields should be initialized inline", Justification = "To ensure initialization logic ordered as specified in class constructor.", Scope = "member", Target = "~M:Rules.Framework.Evaluation.OperatorsMetadata.#cctor")]

--- a/src/Rules.Framework/Management/ManagementOperations.cs
+++ b/src/Rules.Framework/Management/ManagementOperations.cs
@@ -9,7 +9,7 @@ namespace Rules.Framework.Management
             IEnumerable<Rule<TContentType, TConditionType>> rules)
             => new ManagementOperationsSelector<TContentType, TConditionType>(rules);
 
-        internal class ManagementOperationsSelector<TContentType, TConditionType>
+        internal sealed class ManagementOperationsSelector<TContentType, TConditionType>
         {
             private readonly IEnumerable<Rule<TContentType, TConditionType>> rules;
 

--- a/src/Rules.Framework/Management/ManagementOperationsController.cs
+++ b/src/Rules.Framework/Management/ManagementOperationsController.cs
@@ -5,7 +5,7 @@ namespace Rules.Framework.Management
     using Rules.Framework.Core;
     using Rules.Framework.Management.Operations;
 
-    internal class ManagementOperationsController<TContentType, TConditionType>
+    internal sealed class ManagementOperationsController<TContentType, TConditionType>
     {
         private readonly List<IManagementOperation<TContentType, TConditionType>> managementOperations;
         private readonly IEnumerable<Rule<TContentType, TConditionType>> rules;

--- a/src/Rules.Framework/Management/Operations/AddRuleManagementOperation.cs
+++ b/src/Rules.Framework/Management/Operations/AddRuleManagementOperation.cs
@@ -4,7 +4,7 @@ namespace Rules.Framework.Management.Operations
     using System.Threading.Tasks;
     using Rules.Framework.Core;
 
-    internal class AddRuleManagementOperation<TContentType, TConditionType> : IManagementOperation<TContentType, TConditionType>
+    internal sealed class AddRuleManagementOperation<TContentType, TConditionType> : IManagementOperation<TContentType, TConditionType>
     {
         private readonly Rule<TContentType, TConditionType> rule;
         private readonly IRulesDataSource<TContentType, TConditionType> rulesDataSource;

--- a/src/Rules.Framework/Management/Operations/FilterPrioritiesRangeManagementOperation.cs
+++ b/src/Rules.Framework/Management/Operations/FilterPrioritiesRangeManagementOperation.cs
@@ -5,7 +5,7 @@ namespace Rules.Framework.Management.Operations
     using System.Threading.Tasks;
     using Rules.Framework.Core;
 
-    internal class FilterPrioritiesRangeManagementOperation<TContentType, TConditionType> : IManagementOperation<TContentType, TConditionType>
+    internal sealed class FilterPrioritiesRangeManagementOperation<TContentType, TConditionType> : IManagementOperation<TContentType, TConditionType>
     {
         private readonly int? topPriorityThreshold;
         private readonly int? bottomPriorityThreshold;

--- a/src/Rules.Framework/Management/Operations/MovePriorityManagementOperation.cs
+++ b/src/Rules.Framework/Management/Operations/MovePriorityManagementOperation.cs
@@ -5,7 +5,7 @@ namespace Rules.Framework.Management.Operations
     using System.Threading.Tasks;
     using Rules.Framework.Core;
 
-    internal class MovePriorityManagementOperation<TContentType, TConditionType> : IManagementOperation<TContentType, TConditionType>
+    internal sealed class MovePriorityManagementOperation<TContentType, TConditionType> : IManagementOperation<TContentType, TConditionType>
     {
         private readonly int priorityMoveFactor;
 

--- a/src/Rules.Framework/Management/Operations/SetRuleForUpdateManagementOperation.cs
+++ b/src/Rules.Framework/Management/Operations/SetRuleForUpdateManagementOperation.cs
@@ -6,7 +6,7 @@ namespace Rules.Framework.Management.Operations
     using System.Threading.Tasks;
     using Rules.Framework.Core;
 
-    internal class SetRuleForUpdateManagementOperation<TContentType, TConditionType> : IManagementOperation<TContentType, TConditionType>
+    internal sealed class SetRuleForUpdateManagementOperation<TContentType, TConditionType> : IManagementOperation<TContentType, TConditionType>
     {
         private readonly Rule<TContentType, TConditionType> updatedRule;
 

--- a/src/Rules.Framework/Management/Operations/UpdateRulesManagementOperation.cs
+++ b/src/Rules.Framework/Management/Operations/UpdateRulesManagementOperation.cs
@@ -4,7 +4,7 @@ namespace Rules.Framework.Management.Operations
     using System.Threading.Tasks;
     using Rules.Framework.Core;
 
-    internal class UpdateRulesManagementOperation<TContentType, TConditionType> : IManagementOperation<TContentType, TConditionType>
+    internal sealed class UpdateRulesManagementOperation<TContentType, TConditionType> : IManagementOperation<TContentType, TConditionType>
     {
         private readonly IRulesDataSource<TContentType, TConditionType> rulesDataSource;
 

--- a/src/Rules.Framework/PriorityCriterias.cs
+++ b/src/Rules.Framework/PriorityCriterias.cs
@@ -3,7 +3,7 @@ namespace Rules.Framework
     /// <summary>
     /// Defines the available rules engine priority criterias to untie when multiple rules are matched to the set of conditions supplied.
     /// </summary>
-    public enum PriorityCriterias
+    public enum PriorityCriterias : byte
     {
         /// <summary>
         /// Sets the rule with the lowest priority number to win on a untie scenario.

--- a/src/Rules.Framework/PriorityOptions.cs
+++ b/src/Rules.Framework/PriorityOptions.cs
@@ -4,7 +4,7 @@ namespace Rules.Framework
     /// The priority options available to influence the priority at which a new rule is added to
     /// data source.
     /// </summary>
-    public enum PriorityOptions
+    public enum PriorityOptions : byte
     {
         /// <summary>
         /// Specifies to add rule positioned at top of priority values (smallest priority value).

--- a/src/Rules.Framework/Rules.Framework.csproj
+++ b/src/Rules.Framework/Rules.Framework.csproj
@@ -33,7 +33,11 @@
 
   <ItemGroup>
     <PackageReference Include="FluentValidation" Version="10.3.6" />
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3">
+    <PackageReference Include="Meziantou.Analyzer" Version="1.0.756">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Rules.Framework/RulesEngine.cs
+++ b/src/Rules.Framework/RulesEngine.cs
@@ -2,6 +2,7 @@ namespace Rules.Framework
 {
     using System;
     using System.Collections.Generic;
+    using System.Globalization;
     using System.Linq;
     using System.Text;
     using System.Threading.Tasks;
@@ -165,12 +166,12 @@ namespace Rules.Framework
             if (!validationResult.IsValid)
             {
                 StringBuilder stringBuilder = new StringBuilder()
-                    .AppendFormat("Specified '{0}' with invalid search values:", nameof(searchArgs))
+                    .AppendFormat(CultureInfo.InvariantCulture, "Specified '{0}' with invalid search values:", nameof(searchArgs))
                     .AppendLine();
 
                 foreach (ValidationFailure validationFailure in validationResult.Errors)
                 {
-                    stringBuilder.AppendFormat("> {0}", validationFailure.ErrorMessage)
+                    stringBuilder.AppendFormat(CultureInfo.InvariantCulture, "> {0}", validationFailure.ErrorMessage)
                         .AppendLine();
                 }
 
@@ -212,13 +213,13 @@ namespace Rules.Framework
 
         private async Task<RuleOperationResult> AddRuleInternalAsync(Rule<TContentType, TConditionType> rule, RuleAddPriorityOption ruleAddPriorityOption)
         {
-            List<string> errors = new List<string>();
-            RulesFilterArgs<TContentType> rulesFilterArgs = new RulesFilterArgs<TContentType>
+            var errors = new List<string>();
+            var rulesFilterArgs = new RulesFilterArgs<TContentType>
             {
-                ContentType = rule.ContentContainer.ContentType
+                ContentType = rule.ContentContainer.ContentType,
             };
 
-            IEnumerable<Rule<TContentType, TConditionType>> existentRules = await this.rulesDataSource.GetRulesByAsync(rulesFilterArgs).ConfigureAwait(false);
+            var existentRules = await this.rulesDataSource.GetRulesByAsync(rulesFilterArgs).ConfigureAwait(false);
 
             if (ruleAddPriorityOption.PriorityOption == PriorityOptions.AtRuleName
                 && !existentRules.Any(r => string.Equals(r.Name, ruleAddPriorityOption.AtRuleNameOptionValue, StringComparison.OrdinalIgnoreCase)))
@@ -239,65 +240,23 @@ namespace Rules.Framework
             switch (ruleAddPriorityOption.PriorityOption)
             {
                 case PriorityOptions.AtTop:
-                    rule.Priority = 1;
-
-                    await ManagementOperations.Manage(existentRules)
-                        .UsingDataSource(this.rulesDataSource)
-                        .IncreasePriority()
-                        .UpdateRules()
-                        .AddRule(rule)
-                        .ExecuteOperationsAsync()
-                        .ConfigureAwait(false);
+                    await this.AddRuleInternalAtTopAsync(rule, existentRules).ConfigureAwait(false);
 
                     break;
 
                 case PriorityOptions.AtBottom:
 
-                    rule.Priority = !existentRules.Any() ? 1 : existentRules.Max(r => r.Priority) + 1;
-
-                    await ManagementOperations.Manage(existentRules)
-                        .UsingDataSource(this.rulesDataSource)
-                        .AddRule(rule)
-                        .ExecuteOperationsAsync()
-                        .ConfigureAwait(false);
+                    await this.AddRuleInternalAtBottomAsync(rule, existentRules).ConfigureAwait(false);
 
                     break;
 
                 case PriorityOptions.AtPriorityNumber:
-                    int priorityMin = existentRules.MinOrDefault(r => r.Priority);
-                    int priorityMax = existentRules.MaxOrDefault(r => r.Priority);
-
-                    int rulePriority = ruleAddPriorityOption.AtPriorityNumberOptionValue;
-                    rulePriority = Math.Min(rulePriority, priorityMax + 1);
-                    rulePriority = Math.Max(rulePriority, priorityMin);
-
-                    rule.Priority = rulePriority;
-
-                    await ManagementOperations.Manage(existentRules)
-                        .UsingDataSource(this.rulesDataSource)
-                        .FilterFromThresholdPriorityToBottom(rulePriority)
-                        .IncreasePriority()
-                        .UpdateRules()
-                        .AddRule(rule)
-                        .ExecuteOperationsAsync()
-                        .ConfigureAwait(false);
+                    await this.AddRuleInternalAtPriorityNumberAsync(rule, ruleAddPriorityOption, existentRules).ConfigureAwait(false);
 
                     break;
 
                 case PriorityOptions.AtRuleName:
-                    int firstPriorityToIncrement = existentRules
-                        .FirstOrDefault(r => string.Equals(r.Name, ruleAddPriorityOption.AtRuleNameOptionValue, StringComparison.OrdinalIgnoreCase))
-                        .Priority;
-                    rule.Priority = firstPriorityToIncrement;
-
-                    await ManagementOperations.Manage(existentRules)
-                        .UsingDataSource(this.rulesDataSource)
-                        .FilterFromThresholdPriorityToBottom(firstPriorityToIncrement)
-                        .IncreasePriority()
-                        .UpdateRules()
-                        .AddRule(rule)
-                        .ExecuteOperationsAsync()
-                        .ConfigureAwait(false);
+                    await this.AddRuleInternalAtRuleNameAsync(rule, ruleAddPriorityOption, existentRules).ConfigureAwait(false);
 
                     break;
 
@@ -306,6 +265,68 @@ namespace Rules.Framework
             }
 
             return RuleOperationResult.Success();
+        }
+
+        private async Task AddRuleInternalAtBottomAsync(Rule<TContentType, TConditionType> rule, IEnumerable<Rule<TContentType, TConditionType>> existentRules)
+        {
+            rule.Priority = !existentRules.Any() ? 1 : existentRules.Max(r => r.Priority) + 1;
+
+            await ManagementOperations.Manage(existentRules)
+                .UsingDataSource(this.rulesDataSource)
+                .AddRule(rule)
+                .ExecuteOperationsAsync()
+                .ConfigureAwait(false);
+        }
+
+        private async Task AddRuleInternalAtPriorityNumberAsync(Rule<TContentType, TConditionType> rule, RuleAddPriorityOption ruleAddPriorityOption, IEnumerable<Rule<TContentType, TConditionType>> existentRules)
+        {
+            int priorityMin = existentRules.MinOrDefault(r => r.Priority);
+            int priorityMax = existentRules.MaxOrDefault(r => r.Priority);
+
+            int rulePriority = ruleAddPriorityOption.AtPriorityNumberOptionValue;
+            rulePriority = Math.Min(rulePriority, priorityMax + 1);
+            rulePriority = Math.Max(rulePriority, priorityMin);
+
+            rule.Priority = rulePriority;
+
+            await ManagementOperations.Manage(existentRules)
+                .UsingDataSource(this.rulesDataSource)
+                .FilterFromThresholdPriorityToBottom(rulePriority)
+                .IncreasePriority()
+                .UpdateRules()
+                .AddRule(rule)
+                .ExecuteOperationsAsync()
+                .ConfigureAwait(false);
+        }
+
+        private async Task AddRuleInternalAtRuleNameAsync(Rule<TContentType, TConditionType> rule, RuleAddPriorityOption ruleAddPriorityOption, IEnumerable<Rule<TContentType, TConditionType>> existentRules)
+        {
+            int firstPriorityToIncrement = existentRules
+                                    .FirstOrDefault(r => string.Equals(r.Name, ruleAddPriorityOption.AtRuleNameOptionValue, StringComparison.OrdinalIgnoreCase))
+                                    .Priority;
+            rule.Priority = firstPriorityToIncrement;
+
+            await ManagementOperations.Manage(existentRules)
+                .UsingDataSource(this.rulesDataSource)
+                .FilterFromThresholdPriorityToBottom(firstPriorityToIncrement)
+                .IncreasePriority()
+                .UpdateRules()
+                .AddRule(rule)
+                .ExecuteOperationsAsync()
+                .ConfigureAwait(false);
+        }
+
+        private async Task AddRuleInternalAtTopAsync(Rule<TContentType, TConditionType> rule, IEnumerable<Rule<TContentType, TConditionType>> existentRules)
+        {
+            rule.Priority = 1;
+
+            await ManagementOperations.Manage(existentRules)
+                .UsingDataSource(this.rulesDataSource)
+                .IncreasePriority()
+                .UpdateRules()
+                .AddRule(rule)
+                .ExecuteOperationsAsync()
+                .ConfigureAwait(false);
         }
 
         private async Task<IEnumerable<Rule<TContentType, TConditionType>>> MatchAsync(
@@ -317,8 +338,10 @@ namespace Rules.Framework
         {
             IEnumerable<Rule<TContentType, TConditionType>> rules = await this.rulesDataSource.GetRulesAsync(contentType, matchDateBegin, matchDateEnd).ConfigureAwait(false);
 
+            var conditionsAsDictionary = conditions.ToDictionary(ks => ks.Type, ks => ks.Value);
+
             IEnumerable<Rule<TContentType, TConditionType>> matchedRules = rules
-                .Where(r => r.RootCondition == null || this.conditionsEvalEngine.Eval(r.RootCondition, conditions, evaluationOptions))
+                .Where(r => r.RootCondition == null || this.conditionsEvalEngine.Eval(r.RootCondition, conditionsAsDictionary, evaluationOptions))
                 .ToList();
 
             return matchedRules;

--- a/src/Rules.Framework/Validation/SearchArgsValidator.cs
+++ b/src/Rules.Framework/Validation/SearchArgsValidator.cs
@@ -3,7 +3,7 @@ namespace Rules.Framework.Validation
     using System;
     using FluentValidation;
 
-    internal class SearchArgsValidator<TContentType, TConditionType> : AbstractValidator<SearchArgs<TContentType, TConditionType>>
+    internal sealed class SearchArgsValidator<TContentType, TConditionType> : AbstractValidator<SearchArgs<TContentType, TConditionType>>
     {
         private readonly Type conditionTypeRuntimeType;
         private readonly Type contentTypeRuntimeType;

--- a/src/Rules.Framework/Validation/ValidationProvider.cs
+++ b/src/Rules.Framework/Validation/ValidationProvider.cs
@@ -4,7 +4,7 @@ namespace Rules.Framework.Validation
     using System.Collections.Generic;
     using FluentValidation;
 
-    internal class ValidationProvider : IValidatorProvider
+    internal sealed class ValidationProvider : IValidatorProvider
     {
         private readonly IDictionary<Type, IValidator> validatorsByType;
 

--- a/tests/Rules.Framework.Providers.InMemory.Tests/InMemoryProviderRulesDataSourceSelectorExtensionsTests.cs
+++ b/tests/Rules.Framework.Providers.InMemory.Tests/InMemoryProviderRulesDataSourceSelectorExtensionsTests.cs
@@ -44,7 +44,7 @@ namespace Rules.Framework.Providers.InMemory.Tests
         public void SetInMemoryDataSource_GivenServiceProvider_RequestsInMemoryRulesStorageAndSetsOnSelector()
         {
             // Arrange
-            InMemoryRulesStorage<ContentType, ConditionType> inMemoryRulesStorage = Mock.Of<InMemoryRulesStorage<ContentType, ConditionType>>();
+            var inMemoryRulesStorage = new InMemoryRulesStorage<ContentType, ConditionType>();
 
             IServiceCollection serviceDescriptors = new ServiceCollection();
             serviceDescriptors.AddSingleton(inMemoryRulesStorage);

--- a/tests/Rules.Framework.Tests/Evaluation/ConditionsEvalEngineTests.cs
+++ b/tests/Rules.Framework.Tests/Evaluation/ConditionsEvalEngineTests.cs
@@ -14,36 +14,75 @@ namespace Rules.Framework.Tests.Evaluation
     public class ConditionsEvalEngineTests
     {
         [Fact]
+        public void Eval_GivenComposedConditionNodeWithAndOperatorAndMissingConditionWithSearchMode_EvalsAndReturnsResult()
+        {
+            // Arrange
+            var condition1 = new ValueConditionNode<ConditionType>(DataTypes.Boolean, ConditionType.IsVip, Operators.Equal, true);
+            var condition2 = new ValueConditionNode<ConditionType>(DataTypes.String, ConditionType.IsoCurrency, Operators.NotEqual, "SGD");
+
+            var composedConditionNode = new ComposedConditionNode<ConditionType>(
+                LogicalOperators.Or,
+                new IConditionNode<ConditionType>[] { condition1, condition2 });
+
+            var conditions = new Dictionary<ConditionType, object>
+            {
+                { ConditionType.IsoCurrency, "SGD" },
+                { ConditionType.IsoCountryCode, "PT" }
+            };
+
+            var evaluationOptions = new EvaluationOptions
+            {
+                MatchMode = MatchModes.Search,
+                ExcludeRulesWithoutSearchConditions = true
+            };
+
+            var mockDeferredEval = new Mock<IDeferredEval>();
+            mockDeferredEval.SetupSequence(x => x.GetDeferredEvalFor(It.IsAny<IValueConditionNode<ConditionType>>(), It.Is<MatchModes>(mm => mm == MatchModes.Exact)))
+                .Returns(() =>
+                {
+                    return (c) => false;
+                })
+                .Returns(() =>
+                {
+                    return (c) => true;
+                })
+                .Throws(new NotImplementedException("Shouldn't have gotten any more deferred evals."));
+            var conditionsTreeAnalyzer = Mock.Of<IConditionsTreeAnalyzer<ConditionType>>();
+
+            var sut = new ConditionsEvalEngine<ConditionType>(mockDeferredEval.Object, conditionsTreeAnalyzer);
+
+            // Act
+            bool actual = sut.Eval(composedConditionNode, conditions, evaluationOptions);
+
+            // Assert
+            actual.Should().BeFalse();
+
+            mockDeferredEval.Verify(x => x.GetDeferredEvalFor(It.IsAny<IValueConditionNode<ConditionType>>(), It.Is<MatchModes>(mm => mm == MatchModes.Exact)), Times.Exactly(0));
+        }
+
+        [Fact]
         public void Eval_GivenComposedConditionNodeWithAndOperatorWithExactMatch_EvalsAndReturnsResult()
         {
             // Arrange
-            BooleanConditionNode<ConditionType> condition1 = new BooleanConditionNode<ConditionType>(ConditionType.IsVip, Operators.Equal, true);
-            StringConditionNode<ConditionType> condition2 = new StringConditionNode<ConditionType>(ConditionType.IsoCurrency, Operators.NotEqual, "SGD");
+            var condition1 = new ValueConditionNode<ConditionType>(DataTypes.Boolean, ConditionType.IsVip, Operators.Equal, true);
+            var condition2 = new ValueConditionNode<ConditionType>(DataTypes.String, ConditionType.IsoCurrency, Operators.NotEqual, "SGD");
 
-            ComposedConditionNode<ConditionType> composedConditionNode = new ComposedConditionNode<ConditionType>(
+            var composedConditionNode = new ComposedConditionNode<ConditionType>(
                 LogicalOperators.And,
                 new IConditionNode<ConditionType>[] { condition1, condition2 });
 
-            IEnumerable<Condition<ConditionType>> conditions = new[]
+            var conditions = new Dictionary<ConditionType, object>
             {
-                new Condition<ConditionType>
-                {
-                    Type = ConditionType.IsoCurrency,
-                    Value = "SGD"
-                },
-                new Condition<ConditionType>
-                {
-                    Type = ConditionType.IsVip,
-                    Value = true
-                }
+                { ConditionType.IsoCurrency, "SGD" },
+                { ConditionType.IsVip, true }
             };
 
-            EvaluationOptions evaluationOptions = new EvaluationOptions
+            var evaluationOptions = new EvaluationOptions
             {
                 MatchMode = MatchModes.Exact
             };
 
-            Mock<IDeferredEval> mockDeferredEval = new Mock<IDeferredEval>();
+            var mockDeferredEval = new Mock<IDeferredEval>();
             mockDeferredEval.SetupSequence(x => x.GetDeferredEvalFor(It.IsAny<IValueConditionNode<ConditionType>>(), It.Is<MatchModes>(mm => mm == MatchModes.Exact)))
                 .Returns(() =>
                 {
@@ -54,8 +93,9 @@ namespace Rules.Framework.Tests.Evaluation
                     return (c) => true;
                 })
                 .Throws(new NotImplementedException("Shouldn't have gotten any more deferred evals."));
+            var conditionsTreeAnalyzer = Mock.Of<IConditionsTreeAnalyzer<ConditionType>>();
 
-            ConditionsEvalEngine<ConditionType> sut = new ConditionsEvalEngine<ConditionType>(mockDeferredEval.Object);
+            var sut = new ConditionsEvalEngine<ConditionType>(mockDeferredEval.Object, conditionsTreeAnalyzer);
 
             // Act
             bool actual = sut.Eval(composedConditionNode, conditions, evaluationOptions);
@@ -70,38 +110,31 @@ namespace Rules.Framework.Tests.Evaluation
         public void Eval_GivenComposedConditionNodeWithEvalOperator_ThrowsNotSupportedException()
         {
             // Arrange
-            BooleanConditionNode<ConditionType> condition1 = new BooleanConditionNode<ConditionType>(ConditionType.IsVip, Operators.Equal, true);
-            StringConditionNode<ConditionType> condition2 = new StringConditionNode<ConditionType>(ConditionType.IsoCurrency, Operators.NotEqual, "SGD");
+            var condition1 = new ValueConditionNode<ConditionType>(DataTypes.Boolean, ConditionType.IsVip, Operators.Equal, true);
+            var condition2 = new ValueConditionNode<ConditionType>(DataTypes.String, ConditionType.IsoCurrency, Operators.NotEqual, "SGD");
 
-            ComposedConditionNode<ConditionType> composedConditionNode = new ComposedConditionNode<ConditionType>(
+            var composedConditionNode = new ComposedConditionNode<ConditionType>(
                 LogicalOperators.Eval,
                 new IConditionNode<ConditionType>[] { condition1, condition2 });
 
-            IEnumerable<Condition<ConditionType>> conditions = new[]
+            var conditions = new Dictionary<ConditionType, object>
             {
-                new Condition<ConditionType>
-                {
-                    Type = ConditionType.IsoCurrency,
-                    Value = "SGD"
-                },
-                new Condition<ConditionType>
-                {
-                    Type = ConditionType.IsVip,
-                    Value = true
-                }
+                { ConditionType.IsoCurrency, "SGD" },
+                { ConditionType.IsVip, true }
             };
 
-            EvaluationOptions evaluationOptions = new EvaluationOptions
+            var evaluationOptions = new EvaluationOptions
             {
                 MatchMode = MatchModes.Exact
             };
 
-            Mock<IDeferredEval> mockDeferredEval = new Mock<IDeferredEval>();
+            var mockDeferredEval = new Mock<IDeferredEval>();
+            var conditionsTreeAnalyzer = Mock.Of<IConditionsTreeAnalyzer<ConditionType>>();
 
-            ConditionsEvalEngine<ConditionType> sut = new ConditionsEvalEngine<ConditionType>(mockDeferredEval.Object);
+            var sut = new ConditionsEvalEngine<ConditionType>(mockDeferredEval.Object, conditionsTreeAnalyzer);
 
             // Act
-            NotSupportedException notSupportedException = Assert.Throws<NotSupportedException>(() => sut.Eval(composedConditionNode, conditions, evaluationOptions));
+            var notSupportedException = Assert.Throws<NotSupportedException>(() => sut.Eval(composedConditionNode, conditions, evaluationOptions));
 
             // Assert
             notSupportedException.Should().NotBeNull();
@@ -113,33 +146,25 @@ namespace Rules.Framework.Tests.Evaluation
         public void Eval_GivenComposedConditionNodeWithOrOperatorWithExactMatch_EvalsAndReturnsResult()
         {
             // Arrange
-            BooleanConditionNode<ConditionType> condition1 = new BooleanConditionNode<ConditionType>(ConditionType.IsVip, Operators.Equal, true);
-            StringConditionNode<ConditionType> condition2 = new StringConditionNode<ConditionType>(ConditionType.IsoCurrency, Operators.NotEqual, "SGD");
+            var condition1 = new ValueConditionNode<ConditionType>(DataTypes.Boolean, ConditionType.IsVip, Operators.Equal, true);
+            var condition2 = new ValueConditionNode<ConditionType>(DataTypes.String, ConditionType.IsoCurrency, Operators.NotEqual, "SGD");
 
-            ComposedConditionNode<ConditionType> composedConditionNode = new ComposedConditionNode<ConditionType>(
+            var composedConditionNode = new ComposedConditionNode<ConditionType>(
                 LogicalOperators.Or,
                 new IConditionNode<ConditionType>[] { condition1, condition2 });
 
-            IEnumerable<Condition<ConditionType>> conditions = new[]
+            var conditions = new Dictionary<ConditionType, object>
             {
-                new Condition<ConditionType>
-                {
-                    Type = ConditionType.IsoCurrency,
-                    Value = "SGD"
-                },
-                new Condition<ConditionType>
-                {
-                    Type = ConditionType.IsVip,
-                    Value = true
-                }
+                { ConditionType.IsoCurrency, "SGD" },
+                { ConditionType.IsVip, true }
             };
 
-            EvaluationOptions evaluationOptions = new EvaluationOptions
+            var evaluationOptions = new EvaluationOptions
             {
                 MatchMode = MatchModes.Exact
             };
 
-            Mock<IDeferredEval> mockDeferredEval = new Mock<IDeferredEval>();
+            var mockDeferredEval = new Mock<IDeferredEval>();
             mockDeferredEval.SetupSequence(x => x.GetDeferredEvalFor(It.IsAny<IValueConditionNode<ConditionType>>(), It.Is<MatchModes>(mm => mm == MatchModes.Exact)))
                 .Returns(() =>
                 {
@@ -150,8 +175,9 @@ namespace Rules.Framework.Tests.Evaluation
                     return (c) => true;
                 })
                 .Throws(new NotImplementedException("Shouldn't have gotten any more deferred evals."));
+            var conditionsTreeAnalyzer = Mock.Of<IConditionsTreeAnalyzer<ConditionType>>();
 
-            ConditionsEvalEngine<ConditionType> sut = new ConditionsEvalEngine<ConditionType>(mockDeferredEval.Object);
+            var sut = new ConditionsEvalEngine<ConditionType>(mockDeferredEval.Object, conditionsTreeAnalyzer);
 
             // Act
             bool actual = sut.Eval(composedConditionNode, conditions, evaluationOptions);
@@ -166,147 +192,32 @@ namespace Rules.Framework.Tests.Evaluation
         public void Eval_GivenComposedConditionNodeWithUnknownConditionNode_ThrowsNotSupportedException()
         {
             // Arrange
-            Mock<IConditionNode<ConditionType>> mockConditionNode = new Mock<IConditionNode<ConditionType>>();
+            var mockConditionNode = new Mock<IConditionNode<ConditionType>>();
 
-            IEnumerable<Condition<ConditionType>> conditions = new[]
+            var conditions = new Dictionary<ConditionType, object>
             {
-                new Condition<ConditionType>
-                {
-                    Type = ConditionType.IsoCurrency,
-                    Value = "SGD"
-                },
-                new Condition<ConditionType>
-                {
-                    Type = ConditionType.IsVip,
-                    Value = true
-                }
+                { ConditionType.IsoCurrency, "SGD" },
+                { ConditionType.IsVip, true }
             };
 
-            EvaluationOptions evaluationOptions = new EvaluationOptions
+            var evaluationOptions = new EvaluationOptions
             {
                 MatchMode = MatchModes.Exact
             };
 
-            Mock<IDeferredEval> mockDeferredEval = new Mock<IDeferredEval>();
+            var mockDeferredEval = new Mock<IDeferredEval>();
+            var conditionsTreeAnalyzer = Mock.Of<IConditionsTreeAnalyzer<ConditionType>>();
 
-            ConditionsEvalEngine<ConditionType> sut = new ConditionsEvalEngine<ConditionType>(mockDeferredEval.Object);
+            var sut = new ConditionsEvalEngine<ConditionType>(mockDeferredEval.Object, conditionsTreeAnalyzer);
 
             // Act
-            NotSupportedException notSupportedException = Assert.Throws<NotSupportedException>(() => sut.Eval(mockConditionNode.Object, conditions, evaluationOptions));
+            var notSupportedException = Assert.Throws<NotSupportedException>(() => sut.Eval(mockConditionNode.Object, conditions, evaluationOptions));
 
             // Assert
             notSupportedException.Should().NotBeNull();
             notSupportedException.Message.Should().Be($"Unsupported condition node: '{mockConditionNode.Object.GetType().Name}'.");
 
             mockDeferredEval.Verify(x => x.GetDeferredEvalFor(It.IsAny<IValueConditionNode<ConditionType>>(), It.Is<MatchModes>(mm => mm == MatchModes.Exact)), Times.Never());
-        }
-
-        [Fact]
-        public void Eval_GivenComposedConditionNodeWithAndOperatorAndMissingConditionWithSearchMode_EvalsAndReturnsResult()
-        {
-            // Arrange
-            BooleanConditionNode<ConditionType> condition1 = new BooleanConditionNode<ConditionType>(ConditionType.IsVip, Operators.Equal, true);
-            StringConditionNode<ConditionType> condition2 = new StringConditionNode<ConditionType>(ConditionType.IsoCurrency, Operators.NotEqual, "SGD");
-
-            ComposedConditionNode<ConditionType> composedConditionNode = new ComposedConditionNode<ConditionType>(
-                LogicalOperators.Or,
-                new IConditionNode<ConditionType>[] { condition1, condition2 });
-
-            IEnumerable<Condition<ConditionType>> conditions = new[]
-            {
-                new Condition<ConditionType>
-                {
-                    Type = ConditionType.IsoCurrency,
-                    Value = "SGD"
-                },
-                new Condition<ConditionType>
-                {
-                    Type = ConditionType.IsoCountryCode,
-                    Value = "PT"
-                }
-            };
-
-            EvaluationOptions evaluationOptions = new EvaluationOptions
-            {
-                MatchMode = MatchModes.Search,
-                ExcludeRulesWithoutSearchConditions = true
-            };
-
-            Mock<IDeferredEval> mockDeferredEval = new Mock<IDeferredEval>();
-            mockDeferredEval.SetupSequence(x => x.GetDeferredEvalFor(It.IsAny<IValueConditionNode<ConditionType>>(), It.Is<MatchModes>(mm => mm == MatchModes.Exact)))
-                .Returns(() =>
-                {
-                    return (c) => false;
-                })
-                .Returns(() =>
-                {
-                    return (c) => true;
-                })
-                .Throws(new NotImplementedException("Shouldn't have gotten any more deferred evals."));
-
-            ConditionsEvalEngine<ConditionType> sut = new ConditionsEvalEngine<ConditionType>(mockDeferredEval.Object);
-
-            // Act
-            bool actual = sut.Eval(composedConditionNode, conditions, evaluationOptions);
-
-            // Assert
-            actual.Should().BeFalse();
-
-            mockDeferredEval.Verify(x => x.GetDeferredEvalFor(It.IsAny<IValueConditionNode<ConditionType>>(), It.Is<MatchModes>(mm => mm == MatchModes.Exact)), Times.Exactly(0));
-        }
-
-        [Fact]
-        public void Eval_GivenComposedConditionNodeWithAndOperatorAndUnknownConditionNodeWithSearchMode_ThrowsNotSupportedException()
-        {
-            // Arrange
-            StubConditionNode<ConditionType> condition1 = new StubConditionNode<ConditionType>();
-            StringConditionNode<ConditionType> condition2 = new StringConditionNode<ConditionType>(ConditionType.IsoCurrency, Operators.NotEqual, "SGD");
-
-            ComposedConditionNode<ConditionType> composedConditionNode = new ComposedConditionNode<ConditionType>(
-                LogicalOperators.Or,
-                new IConditionNode<ConditionType>[] { condition1, condition2 });
-
-            IEnumerable<Condition<ConditionType>> conditions = new[]
-            {
-                new Condition<ConditionType>
-                {
-                    Type = ConditionType.IsoCurrency,
-                    Value = "SGD"
-                },
-                new Condition<ConditionType>
-                {
-                    Type = ConditionType.IsoCountryCode,
-                    Value = "PT"
-                }
-            };
-
-            EvaluationOptions evaluationOptions = new EvaluationOptions
-            {
-                MatchMode = MatchModes.Search,
-                ExcludeRulesWithoutSearchConditions = true
-            };
-
-            Mock<IDeferredEval> mockDeferredEval = new Mock<IDeferredEval>();
-            mockDeferredEval.SetupSequence(x => x.GetDeferredEvalFor(It.IsAny<IValueConditionNode<ConditionType>>(), It.Is<MatchModes>(mm => mm == MatchModes.Exact)))
-                .Returns(() =>
-                {
-                    return (c) => false;
-                })
-                .Returns(() =>
-                {
-                    return (c) => true;
-                })
-                .Throws(new NotImplementedException("Shouldn't have gotten any more deferred evals."));
-
-            ConditionsEvalEngine<ConditionType> sut = new ConditionsEvalEngine<ConditionType>(mockDeferredEval.Object);
-
-            // Act
-            NotSupportedException notSupportedException = Assert.Throws<NotSupportedException>(() => sut.Eval(composedConditionNode, conditions, evaluationOptions));
-
-            // Assert
-            notSupportedException.Should().NotBeNull();
-            notSupportedException.Message.Should().Be("Unsupported condition node: 'StubConditionNode`1'.");
-            mockDeferredEval.Verify(x => x.GetDeferredEvalFor(It.IsAny<IValueConditionNode<ConditionType>>(), It.Is<MatchModes>(mm => mm == MatchModes.Exact)), Times.Exactly(0));
         }
     }
 }

--- a/tests/Rules.Framework.Tests/Evaluation/ConditionsTreeAnalyzerTests.cs
+++ b/tests/Rules.Framework.Tests/Evaluation/ConditionsTreeAnalyzerTests.cs
@@ -1,0 +1,112 @@
+namespace Rules.Framework.Tests.Evaluation
+{
+    using System;
+    using System.Collections.Generic;
+    using FluentAssertions;
+    using Rules.Framework.Core;
+    using Rules.Framework.Core.ConditionNodes;
+    using Rules.Framework.Evaluation;
+    using Rules.Framework.Tests.TestStubs;
+    using Xunit;
+
+    public class ConditionsTreeAnalyzerTests
+    {
+        [Fact]
+        public void AreAllSearchConditionsPresent_GivenComposedConditionNodeWithAllConditionsOnDictionary_ReturnsTrue()
+        {
+            // Arrange
+            var condition1 = new ValueConditionNode<ConditionType>(DataTypes.String, ConditionType.IsoCountryCode, Operators.In, new[] { "US", "CA" });
+            var condition2 = new ValueConditionNode<ConditionType>(DataTypes.String, ConditionType.IsoCurrency, Operators.NotEqual, "SGD");
+            var condition3 = new ValueConditionNode<ConditionType>(DataTypes.Boolean, ConditionType.IsVip, Operators.Equal, false);
+
+            var composedConditionNode = new ComposedConditionNode<ConditionType>(
+                LogicalOperators.Or,
+                new IConditionNode<ConditionType>[] { condition1, condition2, condition3 });
+
+            var conditions = new Dictionary<ConditionType, object>
+            {
+                {
+                    ConditionType.IsoCurrency,
+                    "SGD"
+                },
+                {
+                    ConditionType.IsoCountryCode,
+                    "PT"
+                }
+            };
+
+            var conditionsTreeAnalyzer = new ConditionsTreeAnalyzer<ConditionType>();
+
+            // Act
+            var result = conditionsTreeAnalyzer.AreAllSearchConditionsPresent(composedConditionNode, conditions);
+
+            // Assert
+            result.Should().BeTrue();
+        }
+
+        [Fact]
+        public void AreAllSearchConditionsPresent_GivenComposedConditionNodeWithAndOperatorAndUnknownConditionNode_ThrowsNotSupportedException()
+        {
+            // Arrange
+            var condition1 = new StubConditionNode<ConditionType>();
+            var condition2 = new ValueConditionNode<ConditionType>(DataTypes.String, ConditionType.IsoCurrency, Operators.NotEqual, "SGD");
+
+            var composedConditionNode = new ComposedConditionNode<ConditionType>(
+                LogicalOperators.Or,
+                new IConditionNode<ConditionType>[] { condition1, condition2 });
+
+            var conditions = new Dictionary<ConditionType, object>()
+            {
+                {
+                    ConditionType.IsoCurrency,
+                    "SGD"
+                },
+                {
+                    ConditionType.IsoCountryCode,
+                    "PT"
+                }
+            };
+
+            var conditionsTreeAnalyzer = new ConditionsTreeAnalyzer<ConditionType>();
+
+            // Act
+            var notSupportedException = Assert.Throws<NotSupportedException>(() => conditionsTreeAnalyzer.AreAllSearchConditionsPresent(composedConditionNode, conditions));
+
+            // Assert
+            notSupportedException.Should().NotBeNull();
+            notSupportedException.Message.Should().Be("Unsupported condition node: 'StubConditionNode`1'.");
+        }
+
+        [Fact]
+        public void AreAllSearchConditionsPresent_GivenComposedConditionNodeWithMissingConditionOnDictionary_ReturnsFalse()
+        {
+            // Arrange
+            var condition1 = new ValueConditionNode<ConditionType>(DataTypes.String, ConditionType.IsoCountryCode, Operators.In, new[] { "US", "CA" });
+            var condition3 = new ValueConditionNode<ConditionType>(DataTypes.Boolean, ConditionType.IsVip, Operators.Equal, false);
+
+            var composedConditionNode = new ComposedConditionNode<ConditionType>(
+                LogicalOperators.Or,
+                new IConditionNode<ConditionType>[] { condition1, condition3 });
+
+            var conditions = new Dictionary<ConditionType, object>()
+            {
+                {
+                    ConditionType.IsoCurrency,
+                    "SGD"
+                },
+                {
+                    ConditionType.IsoCountryCode,
+                    "PT"
+                }
+            };
+
+            var conditionsTreeAnalyzer = new ConditionsTreeAnalyzer<ConditionType>();
+
+            // Act
+            var result = conditionsTreeAnalyzer.AreAllSearchConditionsPresent(composedConditionNode, conditions);
+
+            // Assert
+            result.Should().BeFalse();
+        }
+    }
+}

--- a/tests/Rules.Framework.Tests/Evaluation/ConditionsTreeAnalyzerTests.cs
+++ b/tests/Rules.Framework.Tests/Evaluation/ConditionsTreeAnalyzerTests.cs
@@ -55,7 +55,7 @@ namespace Rules.Framework.Tests.Evaluation
                 LogicalOperators.Or,
                 new IConditionNode<ConditionType>[] { condition1, condition2 });
 
-            var conditions = new Dictionary<ConditionType, object>()
+            var conditions = new Dictionary<ConditionType, object>
             {
                 {
                     ConditionType.IsoCurrency,
@@ -88,7 +88,7 @@ namespace Rules.Framework.Tests.Evaluation
                 LogicalOperators.Or,
                 new IConditionNode<ConditionType>[] { condition1, condition3 });
 
-            var conditions = new Dictionary<ConditionType, object>()
+            var conditions = new Dictionary<ConditionType, object>
             {
                 {
                     ConditionType.IsoCurrency,

--- a/tests/Rules.Framework.Tests/Evaluation/MultiplicityEvaluatorTests.cs
+++ b/tests/Rules.Framework.Tests/Evaluation/MultiplicityEvaluatorTests.cs
@@ -1,0 +1,56 @@
+namespace Rules.Framework.Tests.Evaluation
+{
+    using System;
+    using System.Collections.Generic;
+    using FluentAssertions;
+    using Rules.Framework.Core;
+    using Rules.Framework.Evaluation;
+    using Xunit;
+
+    public class MultiplicityEvaluatorTests
+    {
+        public static IEnumerable<object[]> SuccessCombinations => new[]
+        {
+            new object[] { 1, Operators.Equal, 2, Multiplicities.OneToOne },
+            new object[] { 1, Operators.Equal, new[] { 1, 2 }, Multiplicities.OneToMany },
+            new object[] { new[] { 1, 2 }, Operators.Equal, new[] { 1, 2 }, Multiplicities.ManyToMany },
+            new object[] { new[] { 1, 2 }, Operators.Equal, 2 , Multiplicities.ManyToOne },
+            new object[] { null, Operators.Equal, new[] { 1, 2 } , Multiplicities.OneToMany },
+            new object[] { null, Operators.Equal, 2 , Multiplicities.OneToOne },
+        };
+
+        [Theory]
+        [MemberData(nameof(SuccessCombinations))]
+        public void EvaluateMultiplicity_GivenLeftOperandOperatorAndRightOperand_ReturnsMultiplicity(
+            object leftOperand,
+            Operators @operator,
+            object rightOperand,
+            string expectedMultiplicity)
+        {
+            // Arrange
+            var multiplicityEvaluator = new MultiplicityEvaluator();
+
+            // Act
+            var multiplicity = multiplicityEvaluator.EvaluateMultiplicity(leftOperand, @operator, rightOperand);
+
+            // Assert
+            multiplicity.Should().NotBeNullOrWhiteSpace().And.Be(expectedMultiplicity);
+        }
+
+        [Fact]
+        public void EvaluateMultiplicity_GivenLeftOperandUnknownOperatorAndRightOperand_ThrowsNotSupportedException()
+        {
+            // Arrange
+            object leftOperand = null;
+            const Operators @operator = 0;
+            const int rightOperand = 1;
+            var multiplicityEvaluator = new MultiplicityEvaluator();
+
+            // Act
+            var notSupportedException = Assert.Throws<NotSupportedException>(() => multiplicityEvaluator.EvaluateMultiplicity(leftOperand, @operator, rightOperand));
+
+            // Assert
+            notSupportedException.Should().NotBeNull();
+        }
+    }
+}

--- a/tests/Rules.Framework.Tests/Evaluation/OperatorMetadataTests.cs
+++ b/tests/Rules.Framework.Tests/Evaluation/OperatorMetadataTests.cs
@@ -1,0 +1,79 @@
+namespace Rules.Framework.Tests.Evaluation
+{
+    using System.Linq;
+    using FluentAssertions;
+    using Rules.Framework.Core;
+    using Rules.Framework.Evaluation;
+    using Xunit;
+
+    public class OperatorMetadataTests
+    {
+        [Fact]
+        public void GetAllCombinations_NoConditions_ReturnsAllMultiplicitiesCombinedWithOperator()
+        {
+            // Arrange
+            var expectedCombination = $"{Multiplicities.ManyToOne}-{Operators.Contains}";
+
+            var operatorMetadata = new OperatorMetadata
+            {
+                Operator = Operators.Contains,
+                SupportedMultiplicities = new[] { Multiplicities.ManyToOne }
+            };
+
+            // Act
+            var combinations = operatorMetadata.GetAllCombinations();
+
+            // Assert
+            combinations.Should().NotBeNull().And.HaveCount(1);
+            combinations.First().Should().Be(expectedCombination);
+        }
+
+        [Fact]
+        public void HasSupportForOneMultiplicityAtLeft_WhenHasAtLeastOneToAnyMultiplicity_ReturnsTrue()
+        {
+            // Arrange
+            var operatorMetadata = new OperatorMetadata
+            {
+                SupportedMultiplicities = new[] { Multiplicities.OneToMany }
+            };
+
+            // Act
+            var result = operatorMetadata.HasSupportForOneMultiplicityAtLeft;
+
+            // Assert
+            result.Should().BeTrue();
+        }
+
+        [Fact]
+        public void HasSupportForOneMultiplicityAtLeft_WhenHasNoneOneToAnyMultiplicity_ReturnsFalse()
+        {
+            // Arrange
+            var operatorMetadata = new OperatorMetadata
+            {
+                SupportedMultiplicities = new[] { Multiplicities.ManyToOne }
+            };
+
+            // Act
+            var result = operatorMetadata.HasSupportForOneMultiplicityAtLeft;
+
+            // Assert
+            result.Should().BeFalse();
+        }
+
+        [Fact]
+        public void HasSupportForOneMultiplicityAtLeft_WhenSupportedMultiplicitiesIsNull_ReturnsFalse()
+        {
+            // Arrange
+            var operatorMetadata = new OperatorMetadata
+            {
+                SupportedMultiplicities = null
+            };
+
+            // Act
+            var result = operatorMetadata.HasSupportForOneMultiplicityAtLeft;
+
+            // Assert
+            result.Should().BeFalse();
+        }
+    }
+}

--- a/tests/Rules.Framework.Tests/Evaluation/ValueEvaluation/DeferredEvalTests.cs
+++ b/tests/Rules.Framework.Tests/Evaluation/ValueEvaluation/DeferredEvalTests.cs
@@ -18,33 +18,29 @@ namespace Rules.Framework.Tests.Evaluation.ValueEvaluation
         public void GetDeferredEvalFor_GivenBooleanConditionNode_ReturnsFuncToEvalConditionsCollection()
         {
             // Arrange
-            BooleanConditionNode<ConditionType> conditionNode = new BooleanConditionNode<ConditionType>(ConditionType.IsVip, Operators.NotEqual, true);
+            var conditionNode = new BooleanConditionNode<ConditionType>(ConditionType.IsVip, Operators.NotEqual, true);
 
-            Mock<IConditionEvalDispatcher> mockOperatorEvalStrategy = new Mock<IConditionEvalDispatcher>();
+            var mockOperatorEvalStrategy = new Mock<IConditionEvalDispatcher>();
             mockOperatorEvalStrategy.Setup(x => x.EvalDispatch(It.IsAny<DataTypes>(), It.IsAny<object>(), It.IsAny<Operators>(), It.IsAny<object>()))
                 .Returns(true);
 
-            Mock<IConditionEvalDispatchProvider> mockConditionEvalDispatchProvider = new Mock<IConditionEvalDispatchProvider>();
+            var mockConditionEvalDispatchProvider = new Mock<IConditionEvalDispatchProvider>();
             mockConditionEvalDispatchProvider.Setup(x => x.GetEvalDispatcher(It.IsAny<object>(), It.IsAny<Operators>(), It.IsAny<object>()))
                 .Returns(mockOperatorEvalStrategy.Object);
 
-            IEnumerable<Condition<ConditionType>> conditions = new Condition<ConditionType>[]
+            var conditions = new Dictionary<ConditionType, object>
             {
-                new Condition<ConditionType>
-                {
-                    Type = ConditionType.IsVip,
-                    Value = false
-                }
+                { ConditionType.IsVip, false }
             };
 
-            MatchModes matchMode = MatchModes.Exact;
+            var matchMode = MatchModes.Exact;
 
-            RulesEngineOptions rulesEngineOptions = RulesEngineOptions.NewWithDefaults();
+            var rulesEngineOptions = RulesEngineOptions.NewWithDefaults();
 
-            DeferredEval sut = new DeferredEval(mockConditionEvalDispatchProvider.Object, rulesEngineOptions);
+            var sut = new DeferredEval(mockConditionEvalDispatchProvider.Object, rulesEngineOptions);
 
             // Act
-            Func<IEnumerable<Condition<ConditionType>>, bool> actual = sut.GetDeferredEvalFor(conditionNode, matchMode);
+            var actual = sut.GetDeferredEvalFor(conditionNode, matchMode);
             bool actualEvalResult = actual.Invoke(conditions);
 
             // Assert
@@ -58,34 +54,30 @@ namespace Rules.Framework.Tests.Evaluation.ValueEvaluation
         public void GetDeferredEvalFor_GivenDecimalConditionNode_ReturnsFuncToEvalConditionsCollection()
         {
             // Arrange
-            DecimalConditionNode<ConditionType> conditionNode = new DecimalConditionNode<ConditionType>(ConditionType.PluviosityRate, Operators.GreaterThan, 50);
+            var conditionNode = new DecimalConditionNode<ConditionType>(ConditionType.PluviosityRate, Operators.GreaterThan, 50);
 
-            Mock<IConditionEvalDispatcher> mockOperatorEvalStrategy = new Mock<IConditionEvalDispatcher>();
+            var mockOperatorEvalStrategy = new Mock<IConditionEvalDispatcher>();
             mockOperatorEvalStrategy.Setup(x => x.EvalDispatch(It.IsAny<DataTypes>(), It.IsAny<object>(), It.IsAny<Operators>(), It.IsAny<object>()))
                 .Returns(true);
 
-            Mock<IConditionEvalDispatchProvider> mockConditionEvalDispatchProvider = new Mock<IConditionEvalDispatchProvider>();
+            var mockConditionEvalDispatchProvider = new Mock<IConditionEvalDispatchProvider>();
             mockConditionEvalDispatchProvider.Setup(x => x.GetEvalDispatcher(It.IsAny<object>(), It.IsAny<Operators>(), It.IsAny<object>()))
                 .Returns(mockOperatorEvalStrategy.Object);
 
-            IEnumerable<Condition<ConditionType>> conditions = new Condition<ConditionType>[]
+            var conditions = new Dictionary<ConditionType, object>
             {
-                new Condition<ConditionType>
-                {
-                    Type = ConditionType.PluviosityRate,
-                    Value = 78
-                }
+                { ConditionType.PluviosityRate, 78 }
             };
 
-            MatchModes matchMode = MatchModes.Exact;
+            var matchMode = MatchModes.Exact;
 
-            RulesEngineOptions rulesEngineOptions = RulesEngineOptions.NewWithDefaults();
+            var rulesEngineOptions = RulesEngineOptions.NewWithDefaults();
 
-            DeferredEval sut = new DeferredEval(mockConditionEvalDispatchProvider.Object, rulesEngineOptions);
+            var sut = new DeferredEval(mockConditionEvalDispatchProvider.Object, rulesEngineOptions);
 
             // Act
-            Func<IEnumerable<Condition<ConditionType>>, bool> actual = sut.GetDeferredEvalFor(conditionNode, matchMode);
-            bool actualEvalResult = actual.Invoke(conditions);
+            var actual = sut.GetDeferredEvalFor(conditionNode, matchMode);
+            var actualEvalResult = actual.Invoke(conditions);
 
             // Assert
             actualEvalResult.Should().BeTrue();
@@ -98,34 +90,30 @@ namespace Rules.Framework.Tests.Evaluation.ValueEvaluation
         public void GetDeferredEvalFor_GivenIntegerConditionNode_ReturnsFuncToEvalConditionsCollection()
         {
             // Arrange
-            IntegerConditionNode<ConditionType> conditionNode = new IntegerConditionNode<ConditionType>(ConditionType.NumberOfSales, Operators.GreaterThan, 1000);
+            var conditionNode = new IntegerConditionNode<ConditionType>(ConditionType.NumberOfSales, Operators.GreaterThan, 1000);
 
-            Mock<IConditionEvalDispatcher> mockOperatorEvalStrategy = new Mock<IConditionEvalDispatcher>();
+            var mockOperatorEvalStrategy = new Mock<IConditionEvalDispatcher>();
             mockOperatorEvalStrategy.Setup(x => x.EvalDispatch(It.IsAny<DataTypes>(), It.IsAny<object>(), It.IsAny<Operators>(), It.IsAny<object>()))
                 .Returns(true);
 
-            Mock<IConditionEvalDispatchProvider> mockConditionEvalDispatchProvider = new Mock<IConditionEvalDispatchProvider>();
+            var mockConditionEvalDispatchProvider = new Mock<IConditionEvalDispatchProvider>();
             mockConditionEvalDispatchProvider.Setup(x => x.GetEvalDispatcher(It.IsAny<object>(), It.IsAny<Operators>(), It.IsAny<object>()))
                 .Returns(mockOperatorEvalStrategy.Object);
 
-            IEnumerable<Condition<ConditionType>> conditions = new Condition<ConditionType>[]
+            var conditions = new Dictionary<ConditionType, object>
             {
-                new Condition<ConditionType>
-                {
-                    Type = ConditionType.NumberOfSales,
-                    Value = 2300
-                }
+                { ConditionType.NumberOfSales, 2300 }
             };
 
-            MatchModes matchMode = MatchModes.Exact;
+            var matchMode = MatchModes.Exact;
 
-            RulesEngineOptions rulesEngineOptions = RulesEngineOptions.NewWithDefaults();
+            var rulesEngineOptions = RulesEngineOptions.NewWithDefaults();
 
-            DeferredEval sut = new DeferredEval(mockConditionEvalDispatchProvider.Object, rulesEngineOptions);
+            var sut = new DeferredEval(mockConditionEvalDispatchProvider.Object, rulesEngineOptions);
 
             // Act
-            Func<IEnumerable<Condition<ConditionType>>, bool> actual = sut.GetDeferredEvalFor(conditionNode, matchMode);
-            bool actualEvalResult = actual.Invoke(conditions);
+            var actual = sut.GetDeferredEvalFor(conditionNode, matchMode);
+            var actualEvalResult = actual.Invoke(conditions);
 
             // Assert
             actualEvalResult.Should().BeTrue();
@@ -138,34 +126,30 @@ namespace Rules.Framework.Tests.Evaluation.ValueEvaluation
         public void GetDeferredEvalFor_GivenStringConditionNode_ReturnsFuncToEvalConditionsCollection()
         {
             // Arrange
-            StringConditionNode<ConditionType> conditionNode = new StringConditionNode<ConditionType>(ConditionType.IsoCurrency, Operators.Equal, "EUR");
+            var conditionNode = new StringConditionNode<ConditionType>(ConditionType.IsoCurrency, Operators.Equal, "EUR");
 
-            Mock<IConditionEvalDispatcher> mockOperatorEvalStrategy = new Mock<IConditionEvalDispatcher>();
+            var mockOperatorEvalStrategy = new Mock<IConditionEvalDispatcher>();
             mockOperatorEvalStrategy.Setup(x => x.EvalDispatch(It.IsAny<DataTypes>(), It.IsAny<object>(), It.IsAny<Operators>(), It.IsAny<object>()))
                 .Returns(true);
 
-            Mock<IConditionEvalDispatchProvider> mockConditionEvalDispatchProvider = new Mock<IConditionEvalDispatchProvider>();
+            var mockConditionEvalDispatchProvider = new Mock<IConditionEvalDispatchProvider>();
             mockConditionEvalDispatchProvider.Setup(x => x.GetEvalDispatcher(It.IsAny<object>(), It.IsAny<Operators>(), It.IsAny<object>()))
                 .Returns(mockOperatorEvalStrategy.Object);
 
-            IEnumerable<Condition<ConditionType>> conditions = new Condition<ConditionType>[]
+            var conditions = new Dictionary<ConditionType, object>
             {
-                new Condition<ConditionType>
-                {
-                    Type = ConditionType.IsoCurrency,
-                    Value = "EUR"
-                }
+                { ConditionType.IsoCurrency, "EUR" }
             };
 
-            MatchModes matchMode = MatchModes.Exact;
+            var matchMode = MatchModes.Exact;
 
-            RulesEngineOptions rulesEngineOptions = RulesEngineOptions.NewWithDefaults();
+            var rulesEngineOptions = RulesEngineOptions.NewWithDefaults();
 
-            DeferredEval sut = new DeferredEval(mockConditionEvalDispatchProvider.Object, rulesEngineOptions);
+            var sut = new DeferredEval(mockConditionEvalDispatchProvider.Object, rulesEngineOptions);
 
             // Act
-            Func<IEnumerable<Condition<ConditionType>>, bool> actual = sut.GetDeferredEvalFor(conditionNode, matchMode);
-            bool actualEvalResult = actual.Invoke(conditions);
+            var actual = sut.GetDeferredEvalFor(conditionNode, matchMode);
+            var actualEvalResult = actual.Invoke(conditions);
 
             // Assert
             actualEvalResult.Should().BeTrue();
@@ -178,35 +162,31 @@ namespace Rules.Framework.Tests.Evaluation.ValueEvaluation
         public void GetDeferredEvalFor_GivenStringConditionNodeWithNoConditionSuppliedAndRulesEngineConfiguredToDiscardWhenMissing_ReturnsFuncThatEvalsFalse()
         {
             // Arrange
-            StringConditionNode<ConditionType> conditionNode = new StringConditionNode<ConditionType>(ConditionType.IsoCurrency, Operators.Equal, "EUR");
+            var conditionNode = new StringConditionNode<ConditionType>(ConditionType.IsoCurrency, Operators.Equal, "EUR");
 
-            Mock<IConditionEvalDispatcher> mockOperatorEvalStrategy = new Mock<IConditionEvalDispatcher>();
+            var mockOperatorEvalStrategy = new Mock<IConditionEvalDispatcher>();
             mockOperatorEvalStrategy.Setup(x => x.EvalDispatch(It.IsAny<DataTypes>(), It.IsAny<object>(), It.IsAny<Operators>(), It.IsAny<object>()))
                 .Returns(true);
 
-            Mock<IConditionEvalDispatchProvider> mockConditionEvalDispatchProvider = new Mock<IConditionEvalDispatchProvider>();
+            var mockConditionEvalDispatchProvider = new Mock<IConditionEvalDispatchProvider>();
             mockConditionEvalDispatchProvider.Setup(x => x.GetEvalDispatcher(It.IsAny<object>(), It.IsAny<Operators>(), It.IsAny<object>()))
                 .Returns(mockOperatorEvalStrategy.Object);
 
-            IEnumerable<Condition<ConditionType>> conditions = new Condition<ConditionType>[]
+            var conditions = new Dictionary<ConditionType, object>
             {
-                new Condition<ConditionType>
-                {
-                    Type = ConditionType.IsoCountryCode,
-                    Value = "PT"
-                }
+                { ConditionType.IsoCountryCode, "PT" }
             };
 
-            MatchModes matchMode = MatchModes.Exact;
+            var matchMode = MatchModes.Exact;
 
-            RulesEngineOptions rulesEngineOptions = RulesEngineOptions.NewWithDefaults();
+            var rulesEngineOptions = RulesEngineOptions.NewWithDefaults();
             rulesEngineOptions.MissingConditionBehavior = MissingConditionBehaviors.Discard;
 
-            DeferredEval sut = new DeferredEval(mockConditionEvalDispatchProvider.Object, rulesEngineOptions);
+            var sut = new DeferredEval(mockConditionEvalDispatchProvider.Object, rulesEngineOptions);
 
             // Act
-            Func<IEnumerable<Condition<ConditionType>>, bool> actual = sut.GetDeferredEvalFor(conditionNode, matchMode);
-            bool actualEvalResult = actual.Invoke(conditions);
+            var actual = sut.GetDeferredEvalFor(conditionNode, matchMode);
+            var actualEvalResult = actual.Invoke(conditions);
 
             // Assert
             actualEvalResult.Should().BeFalse();
@@ -219,35 +199,31 @@ namespace Rules.Framework.Tests.Evaluation.ValueEvaluation
         public void GetDeferredEvalFor_GivenStringConditionNodeWithNoConditionSuppliedAndRulesEngineConfiguredToUseDataTypeDefaultWhenMissing_ReturnsFuncThatEvalsFalse()
         {
             // Arrange
-            StringConditionNode<ConditionType> conditionNode = new StringConditionNode<ConditionType>(ConditionType.IsoCurrency, Operators.Equal, "EUR");
+            var conditionNode = new StringConditionNode<ConditionType>(ConditionType.IsoCurrency, Operators.Equal, "EUR");
 
-            Mock<IConditionEvalDispatcher> mockOperatorEvalStrategy = new Mock<IConditionEvalDispatcher>();
+            var mockOperatorEvalStrategy = new Mock<IConditionEvalDispatcher>();
             mockOperatorEvalStrategy.Setup(x => x.EvalDispatch(It.IsAny<DataTypes>(), It.IsAny<object>(), It.IsAny<Operators>(), It.IsAny<object>()))
                 .Returns(false);
 
-            Mock<IConditionEvalDispatchProvider> mockConditionEvalDispatchProvider = new Mock<IConditionEvalDispatchProvider>();
+            var mockConditionEvalDispatchProvider = new Mock<IConditionEvalDispatchProvider>();
             mockConditionEvalDispatchProvider.Setup(x => x.GetEvalDispatcher(It.IsAny<object>(), It.IsAny<Operators>(), It.IsAny<object>()))
                 .Returns(mockOperatorEvalStrategy.Object);
 
-            IEnumerable<Condition<ConditionType>> conditions = new Condition<ConditionType>[]
+            var conditions = new Dictionary<ConditionType, object>
             {
-                new Condition<ConditionType>
-                {
-                    Type = ConditionType.IsoCountryCode,
-                    Value = "PT"
-                }
+                { ConditionType.IsoCountryCode, "PT" }
             };
 
-            MatchModes matchMode = MatchModes.Exact;
+            var matchMode = MatchModes.Exact;
 
-            RulesEngineOptions rulesEngineOptions = RulesEngineOptions.NewWithDefaults();
+            var rulesEngineOptions = RulesEngineOptions.NewWithDefaults();
             rulesEngineOptions.MissingConditionBehavior = MissingConditionBehaviors.UseDataTypeDefault;
 
-            DeferredEval sut = new DeferredEval(mockConditionEvalDispatchProvider.Object, rulesEngineOptions);
+            var sut = new DeferredEval(mockConditionEvalDispatchProvider.Object, rulesEngineOptions);
 
             // Act
-            Func<IEnumerable<Condition<ConditionType>>, bool> actual = sut.GetDeferredEvalFor(conditionNode, matchMode);
-            bool actualEvalResult = actual.Invoke(conditions);
+            var actual = sut.GetDeferredEvalFor(conditionNode, matchMode);
+            var actualEvalResult = actual.Invoke(conditions);
 
             // Assert
             actualEvalResult.Should().BeFalse();
@@ -260,18 +236,18 @@ namespace Rules.Framework.Tests.Evaluation.ValueEvaluation
         public void GetDeferredEvalFor_GivenUnknownConditionNodeType_ThrowsNotSupportedException()
         {
             // Arrange
-            Mock<IValueConditionNode<ConditionType>> mockValueConditionNode = new Mock<IValueConditionNode<ConditionType>>();
+            var mockValueConditionNode = new Mock<IValueConditionNode<ConditionType>>();
 
-            Mock<IConditionEvalDispatchProvider> mockConditionEvalDispatchProvider = new Mock<IConditionEvalDispatchProvider>();
+            var mockConditionEvalDispatchProvider = new Mock<IConditionEvalDispatchProvider>();
 
-            MatchModes matchMode = MatchModes.Exact;
+            var matchMode = MatchModes.Exact;
 
-            RulesEngineOptions rulesEngineOptions = RulesEngineOptions.NewWithDefaults();
+            var rulesEngineOptions = RulesEngineOptions.NewWithDefaults();
 
-            DeferredEval sut = new DeferredEval(mockConditionEvalDispatchProvider.Object, rulesEngineOptions);
+            var sut = new DeferredEval(mockConditionEvalDispatchProvider.Object, rulesEngineOptions);
 
             // Act
-            NotSupportedException notSupportedException = Assert.Throws<NotSupportedException>(() => sut.GetDeferredEvalFor(mockValueConditionNode.Object, matchMode));
+            var notSupportedException = Assert.Throws<NotSupportedException>(() => sut.GetDeferredEvalFor(mockValueConditionNode.Object, matchMode));
 
             // Assert
             notSupportedException.Should().NotBeNull();

--- a/tests/Rules.Framework.Tests/RulesEngineTests.cs
+++ b/tests/Rules.Framework.Tests/RulesEngineTests.cs
@@ -68,7 +68,7 @@ namespace Rules.Framework.Tests
             mockRulesDataSource.Verify(x => x.GetRulesAsync(It.IsAny<ContentType>(), It.IsAny<DateTime>(), It.IsAny<DateTime>()), Times.Never());
             mockConditionsEvalEngine.Verify(x => x.Eval(
                 It.IsAny<IConditionNode<ConditionType>>(),
-                It.IsAny<IEnumerable<Condition<ConditionType>>>(),
+                It.IsAny<IDictionary<ConditionType, object>>(),
                 It.Is<EvaluationOptions>(eo => eo == evaluationOptions)), Times.Never());
         }
 
@@ -137,7 +137,7 @@ namespace Rules.Framework.Tests
                 }
             };
 
-            Rule<ContentType, ConditionType> expected1 = new Rule<ContentType, ConditionType>
+            var expected1 = new Rule<ContentType, ConditionType>
             {
                 ContentContainer = new ContentContainer<ContentType>(contentType, (t) => new object()),
                 DateBegin = new DateTime(2018, 01, 01),
@@ -147,7 +147,7 @@ namespace Rules.Framework.Tests
                 RootCondition = new ValueConditionNode<ConditionType>(DataTypes.String, ConditionType.IsoCountryCode, Operators.Equal, "USA")
             };
 
-            Rule<ContentType, ConditionType> expected2 = new Rule<ContentType, ConditionType>
+            var expected2 = new Rule<ContentType, ConditionType>
             {
                 ContentContainer = new ContentContainer<ContentType>(contentType, (t) => new object()),
                 DateBegin = new DateTime(2010, 01, 01),
@@ -157,7 +157,7 @@ namespace Rules.Framework.Tests
                 RootCondition = new ValueConditionNode<ConditionType>(DataTypes.String, ConditionType.IsoCountryCode, Operators.Equal, "USA")
             };
 
-            Rule<ContentType, ConditionType> notExpected = new Rule<ContentType, ConditionType>
+            var notExpected = new Rule<ContentType, ConditionType>
             {
                 ContentContainer = new ContentContainer<ContentType>(contentType, (t) => new object()),
                 DateBegin = new DateTime(2018, 01, 01),
@@ -174,7 +174,7 @@ namespace Rules.Framework.Tests
                 notExpected
             };
 
-            EvaluationOptions evaluationOptions = new EvaluationOptions
+            var evaluationOptions = new EvaluationOptions
             {
                 MatchMode = MatchModes.Exact
             };
@@ -182,24 +182,21 @@ namespace Rules.Framework.Tests
 
             this.SetupMockForConditionsEvalEngine((rootConditionNode, _, _) =>
             {
-                switch (rootConditionNode)
+                return rootConditionNode switch
                 {
-                    case ValueConditionNode<ConditionType> stringConditionNode:
-                        return stringConditionNode.Operand.ToString() == "USA";
-
-                    default:
-                        return false;
-                }
+                    ValueConditionNode<ConditionType> stringConditionNode => stringConditionNode.Operand.ToString() == "USA",
+                    _ => false,
+                };
             }, evaluationOptions);
 
-            IValidatorProvider validatorProvider = Mock.Of<IValidatorProvider>();
+            var validatorProvider = Mock.Of<IValidatorProvider>();
 
-            RulesEngineOptions rulesEngineOptions = RulesEngineOptions.NewWithDefaults();
+            var rulesEngineOptions = RulesEngineOptions.NewWithDefaults();
 
-            RulesEngine<ContentType, ConditionType> sut = new RulesEngine<ContentType, ConditionType>(mockConditionsEvalEngine.Object, mockRulesDataSource.Object, validatorProvider, rulesEngineOptions, mockCondtionTypeExtractor.Object);
+            var sut = new RulesEngine<ContentType, ConditionType>(mockConditionsEvalEngine.Object, mockRulesDataSource.Object, validatorProvider, rulesEngineOptions, mockCondtionTypeExtractor.Object);
 
             // Act
-            IEnumerable<Rule<ContentType, ConditionType>> actual = await sut.MatchManyAsync(contentType, matchDateTime, conditions);
+            var actual = await sut.MatchManyAsync(contentType, matchDateTime, conditions).ConfigureAwait(false);
 
             // Assert
             actual.Should().Contain(expected1)
@@ -208,7 +205,7 @@ namespace Rules.Framework.Tests
             mockRulesDataSource.Verify(x => x.GetRulesAsync(It.IsAny<ContentType>(), It.IsAny<DateTime>(), It.IsAny<DateTime>()), Times.Once());
             mockConditionsEvalEngine.Verify(x => x.Eval(
                 It.IsAny<IConditionNode<ConditionType>>(),
-                It.IsAny<IEnumerable<Condition<ConditionType>>>(),
+                It.IsAny<IDictionary<ConditionType, object>>(),
                 It.Is<EvaluationOptions>(eo => eo == evaluationOptions)), Times.AtLeastOnce());
         }
 
@@ -282,7 +279,7 @@ namespace Rules.Framework.Tests
             mockRulesDataSource.Verify(x => x.GetRulesAsync(It.IsAny<ContentType>(), It.IsAny<DateTime>(), It.IsAny<DateTime>()), Times.Once());
             mockConditionsEvalEngine.Verify(x => x.Eval(
                 It.IsAny<IConditionNode<ConditionType>>(),
-                It.IsAny<IEnumerable<Condition<ConditionType>>>(),
+                It.IsAny<IDictionary<ConditionType, object>>(),
                 It.Is<EvaluationOptions>(eo => eo == evaluationOptions)), Times.AtLeastOnce());
         }
 
@@ -354,7 +351,7 @@ namespace Rules.Framework.Tests
             mockRulesDataSource.Verify(x => x.GetRulesAsync(It.IsAny<ContentType>(), It.IsAny<DateTime>(), It.IsAny<DateTime>()), Times.Once());
             mockConditionsEvalEngine.Verify(x => x.Eval(
                 It.IsAny<IConditionNode<ConditionType>>(),
-                It.IsAny<IEnumerable<Condition<ConditionType>>>(),
+                It.IsAny<IDictionary<ConditionType, object>>(),
                 It.Is<EvaluationOptions>(eo => eo == evaluationOptions)), Times.AtLeastOnce());
         }
 
@@ -422,7 +419,7 @@ namespace Rules.Framework.Tests
             mockRulesDataSource.Verify(x => x.GetRulesAsync(It.IsAny<ContentType>(), It.IsAny<DateTime>(), It.IsAny<DateTime>()), Times.Once());
             mockConditionsEvalEngine.Verify(x => x.Eval(
                 It.IsAny<IConditionNode<ConditionType>>(),
-                It.IsAny<IEnumerable<Condition<ConditionType>>>(),
+                It.IsAny<IDictionary<ConditionType, object>>(),
                 It.Is<EvaluationOptions>(eo => eo == evaluationOptions)), Times.AtLeastOnce());
         }
 
@@ -537,11 +534,11 @@ namespace Rules.Framework.Tests
             argumentNullException.ParamName.Should().Be(nameof(searchArgs));
         }
 
-        private void SetupMockForConditionsEvalEngine(Func<IConditionNode<ConditionType>, IEnumerable<Condition<ConditionType>>, EvaluationOptions, bool> evalFunc, EvaluationOptions evaluationOptions)
+        private void SetupMockForConditionsEvalEngine(Func<IConditionNode<ConditionType>, IDictionary<ConditionType, object>, EvaluationOptions, bool> evalFunc, EvaluationOptions evaluationOptions)
         {
             this.mockConditionsEvalEngine.Setup(x => x.Eval(
                     It.IsAny<IConditionNode<ConditionType>>(),
-                    It.IsAny<IEnumerable<Condition<ConditionType>>>(),
+                    It.IsAny<IDictionary<ConditionType, object>>(),
                     It.Is<EvaluationOptions>(eo => eo == evaluationOptions)))
                 .Returns(evalFunc);
         }
@@ -550,7 +547,7 @@ namespace Rules.Framework.Tests
         {
             this.mockConditionsEvalEngine.Setup(x => x.Eval(
                     It.IsAny<IConditionNode<ConditionType>>(),
-                    It.IsAny<IEnumerable<Condition<ConditionType>>>(),
+                    It.IsAny<IDictionary<ConditionType, object>>(),
                     It.Is<EvaluationOptions>(eo => eo == evaluationOptions)))
                 .Returns(result);
         }

--- a/tests/Rules.Framework.Tests/RulesEngineTests.cs
+++ b/tests/Rules.Framework.Tests/RulesEngineTests.cs
@@ -182,11 +182,7 @@ namespace Rules.Framework.Tests
 
             this.SetupMockForConditionsEvalEngine((rootConditionNode, _, _) =>
             {
-                return rootConditionNode switch
-                {
-                    ValueConditionNode<ConditionType> stringConditionNode => stringConditionNode.Operand.ToString() == "USA",
-                    _ => false,
-                };
+                return rootConditionNode is ValueConditionNode<ConditionType> stringConditionNode && stringConditionNode.Operand.ToString() == "USA";
             }, evaluationOptions);
 
             var validatorProvider = Mock.Of<IValidatorProvider>();


### PR DESCRIPTION
## Description

Various performance improvements to reduce both times taken and memory allocated:

- Use the keyword `sealed` on all internal not inherited/not probable to be inherited types.
- Replace evaluation based on `IEnumerable<Condition<TConditionType>>` by `IDictionary<TConditionType, object>`.
- Re-organize FluentValidation configurations to optimize rules builder validation.
- Set the underlying type of enums (use byte for all).
- Set structs layout for optimizing the memory allocation on the call stack.
- Create operator metadata structure to allow the use of pre-calculated properties of those calculators, reducing rules evaluation times with indexed information: `OperatorMetadata` and `OperatorsMetadata`.
- Add `StringComparer.Ordinal` to collection operations in order to speed up strings comparison.

Also refactored:

- Segregate to a different class the analysis of the conditions: `ConditionsTreeAnalyzer<TConditionType>`.
- Split long methods according to code analysis suggestions.
- Segregate multiplicity evaluation to a separate class to manage the algorithm complexity: `MultiplicityEvaluator`.
- Make use of implicit declarations - `var`.

Related to #49.

## Change checklist

- [x] Code follows the [code rules guidelines](../CONTRIBUTING.md#code-rules) of this project
- [x] Commit messages follow the [commit rules](../CONTRIBUTING.md#commit-rules) of this project
- [x] I have self-reviewed my changes before submitting this pull request
- [x] I have covered new/changed code with new tests and/or adjusted existent ones
- [x] I have made changes necessary to update the documentation accordingly

Please also check the [_I want to contribute_](../CONTRIBUTING.md#i-want-to-contribute) guidelines and make sure you have done accordingly.

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)