### PR TITLE
feat: added Operators.NotIn for arrays Part 1

### DIFF
--- a/src/Rules.Framework/Builder/Validation/ValueConditionNodeValidator.cs
+++ b/src/Rules.Framework/Builder/Validation/ValueConditionNodeValidator.cs
@@ -49,22 +49,22 @@ namespace Rules.Framework.Builder.Validation
                 .WithMessage(cn => $"Condition nodes with data type '{cn.DataType}' can't define a operator of type '{cn.Operator}'.");
 
             this.RuleFor(c => c.Operator)
-                .IsContainedOn(Operators.In)
+                .IsContainedOn(Operators.In, Operators.NotIn, Operators.Equal, Operators.NotEqual)
                 .When(c => c.DataType == DataTypes.ArrayString)
                 .WithMessage(cn => $"Condition nodes with data type '{cn.DataType}' can't define a operator of type '{cn.Operator}'.");
 
             this.RuleFor(c => c.Operator)
-                .IsContainedOn(Operators.In)
+                .IsContainedOn(Operators.In, Operators.NotIn, Operators.Equal, Operators.NotEqual)
                 .When(c => c.DataType == DataTypes.ArrayInteger)
                 .WithMessage(cn => $"Condition nodes with data type '{cn.DataType}' can't define a operator of type '{cn.Operator}'.");
 
             this.RuleFor(c => c.Operator)
-                .IsContainedOn(Operators.In)
+                .IsContainedOn(Operators.In, Operators.NotIn, Operators.Equal, Operators.NotEqual)
                 .When(c => c.DataType == DataTypes.ArrayDecimal)
                 .WithMessage(cn => $"Condition nodes with data type '{cn.DataType}' can't define a operator of type '{cn.Operator}'.");
 
             this.RuleFor(c => c.Operator)
-                .IsContainedOn(Operators.In)
+                .IsContainedOn(Operators.In, Operators.NotIn, Operators.Equal, Operators.NotEqual)
                 .When(c => c.DataType == DataTypes.ArrayBoolean)
                 .WithMessage(cn => $"Condition nodes with data type '{cn.DataType}' can't define a operator of type '{cn.Operator}'.");
         }

--- a/src/Rules.Framework/Core/Operators.cs
+++ b/src/Rules.Framework/Core/Operators.cs
@@ -78,6 +78,11 @@ namespace Rules.Framework.Core
         /// <summary>
         /// The not ends with operator.
         /// </summary>
-        NotEndsWith = 15
+        NotEndsWith = 15,
+
+        /// <summary>
+        /// The not in operator.
+        /// </summary>
+        NotIn = 16,
     }
 }

--- a/src/Rules.Framework/Evaluation/OperatorsMetadata.cs
+++ b/src/Rules.Framework/Evaluation/OperatorsMetadata.cs
@@ -23,6 +23,7 @@ namespace Rules.Framework.Evaluation
             OperatorsMetadata.Contains,
             OperatorsMetadata.NotContains,
             OperatorsMetadata.In,
+            OperatorsMetadata.NotIn,
             OperatorsMetadata.StartsWith,
             OperatorsMetadata.EndsWith,
             OperatorsMetadata.CaseInsensitiveStartsWith,
@@ -136,6 +137,12 @@ namespace Rules.Framework.Evaluation
         {
             Operator = Operators.NotEqual,
             SupportedMultiplicities = new[] { Multiplicities.OneToOne },
+        };
+
+        public static OperatorMetadata NotIn => new()
+        {
+            Operator = Operators.NotIn,
+            SupportedMultiplicities = new[] { Multiplicities.OneToMany },
         };
 
         public static OperatorMetadata NotStartsWith => new()

--- a/src/Rules.Framework/Evaluation/ValueEvaluation/NotInOperatorEvalStrategy.cs
+++ b/src/Rules.Framework/Evaluation/ValueEvaluation/NotInOperatorEvalStrategy.cs
@@ -1,0 +1,11 @@
+namespace Rules.Framework.Evaluation.ValueEvaluation
+{
+    using System.Collections.Generic;
+    using System.Linq;
+
+    internal sealed class NotInOperatorEvalStrategy : IOneToManyOperatorEvalStrategy
+    {
+        public bool Eval(object leftOperand, IEnumerable<object> rightOperand)
+            => !rightOperand.Contains(leftOperand);
+    }
+}

--- a/src/Rules.Framework/Evaluation/ValueEvaluation/OperatorEvalStrategyFactory.cs
+++ b/src/Rules.Framework/Evaluation/ValueEvaluation/OperatorEvalStrategyFactory.cs
@@ -21,6 +21,7 @@ namespace Rules.Framework.Evaluation.ValueEvaluation
                 { Operators.Contains, new ContainsOperatorEvalStrategy() },
                 { Operators.NotContains, new NotContainsOperatorEvalStrategy() },
                 { Operators.In, new InOperatorEvalStrategy() },
+                { Operators.NotIn, new NotInOperatorEvalStrategy() },
                 { Operators.StartsWith, new StartsWithOperatorEvalStrategy() },
                 { Operators.EndsWith, new EndsWithOperatorEvalStrategy() },
                 { Operators.CaseInsensitiveStartsWith, new CaseInsensitiveStartsWithOperatorEvalStrategy() },

--- a/tests/Rules.Framework.Tests/Evaluation/ValueEvaluation/NotInOperatorEvalStrategyTests.cs
+++ b/tests/Rules.Framework.Tests/Evaluation/ValueEvaluation/NotInOperatorEvalStrategyTests.cs
@@ -1,0 +1,42 @@
+namespace Rules.Framework.Tests.Evaluation.ValueEvaluation
+{
+    using System.Linq;
+    using FluentAssertions;
+    using Rules.Framework.Evaluation.ValueEvaluation;
+    using Xunit;
+
+    public class NotInOperatorEvalStrategyTests
+    {
+        [Fact]
+        public void Eval_GivenInteger1AndCollectionContainingInteger1_ReturnsFalse()
+        {
+            // Arrange
+            object leftOperand = 1;
+            var rightOperand = Enumerable.Range(1, 3).Cast<object>();
+
+            var notInOperatorEvalStrategy = new NotInOperatorEvalStrategy();
+
+            // Act
+            var result = notInOperatorEvalStrategy.Eval(leftOperand, rightOperand);
+
+            // Assert
+            result.Should().BeFalse();
+        }
+
+        [Fact]
+        public void Eval_GivenInteger2AndCollectionNotContainingInteger2_ReturnsTrue()
+        {
+            // Arrange
+            object leftOperand = 2;
+            var rightOperand = Enumerable.Range(6, 3).Cast<object>();
+
+            var notInOperatorEvalStrategy = new NotInOperatorEvalStrategy();
+
+            // Act
+            var result = notInOperatorEvalStrategy.Eval(leftOperand, rightOperand);
+
+            // Assert
+            result.Should().BeTrue();
+        }
+    }
+}


### PR DESCRIPTION
## Description

Added Operators.NotIn for arrays (#113)

## Change checklist

- [x] Code follows the [code rules guidelines](../CONTRIBUTING.md#code-rules) of this project
- [x] Commit messages follow the [commit rules](../CONTRIBUTING.md#commit-rules) of this project
- [x] I have self-reviewed my changes before submitting this pull request
- [x] I have covered new/changed code with new tests and/or adjusted existent ones
- [ ] I have made changes necessary to update the documentation accordingly

Please also check the [_I want to contribute_](../CONTRIBUTING.md#i-want-to-contribute) guidelines and make sure you have done accordingly.

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)