### PR TITLE
feat: added Operators.NotIn for arrays Part 2

### DIFF
--- a/src/Rules.Framework.Providers.InMemory/Rules.Framework.Providers.InMemory.csproj
+++ b/src/Rules.Framework.Providers.InMemory/Rules.Framework.Providers.InMemory.csproj
@@ -36,6 +36,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.1.1" />
-    <PackageReference Include="Rules.Framework" Version="1.7.3" />
+    <PackageReference Include="Rules.Framework" Version="1.7.4" />
   </ItemGroup>
 </Project>

--- a/src/Rules.Framework.Providers.MongoDb/Rules.Framework.Providers.MongoDb.csproj
+++ b/src/Rules.Framework.Providers.MongoDb/Rules.Framework.Providers.MongoDb.csproj
@@ -37,6 +37,6 @@
     </PackageReference>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="MongoDB.Driver" Version="2.13.1" />
-    <PackageReference Include="Rules.Framework" Version="1.7.3" />
+    <PackageReference Include="Rules.Framework" Version="1.7.4" />
   </ItemGroup>
 </Project>

--- a/src/Rules.Framework.WebUI/Rules.Framework.WebUI.csproj
+++ b/src/Rules.Framework.WebUI/Rules.Framework.WebUI.csproj
@@ -47,7 +47,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="Rules.Framework" Version="1.7.3" />
+	  <PackageReference Include="Rules.Framework" Version="1.7.4" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/tests/Rules.Framework.Providers.InMemory.IntegrationTests/Tests/Scenario5/BestServerTests.cs
+++ b/tests/Rules.Framework.Providers.InMemory.IntegrationTests/Tests/Scenario5/BestServerTests.cs
@@ -102,6 +102,12 @@ namespace Rules.Framework.Providers.InMemory.IntegrationTests.Tests.Scenario5
                             .SetOperand(new[] { 12, 16, 24, 36 })
                             .Build())
                         .AddCondition(x2 =>
+                            x2.AsValued(BestServerConditions.Memory)
+                            .OfDataType<IEnumerable<int>>()
+                            .WithComparisonOperator(Operators.NotIn)
+                            .SetOperand(new[] { 4, 8 })
+                            .Build())
+                        .AddCondition(x2 =>
                             x2.AsValued(BestServerConditions.StoragePartionable)
                             .OfDataType<IEnumerable<bool>>()
                             .WithComparisonOperator(Operators.In)

--- a/tests/Rules.Framework.Providers.MongoDb.IntegrationTests/Tests/Scenaro5/BestServerTests.cs
+++ b/tests/Rules.Framework.Providers.MongoDb.IntegrationTests/Tests/Scenaro5/BestServerTests.cs
@@ -112,6 +112,12 @@ namespace Rules.Framework.Providers.MongoDb.IntegrationTests.Tests.Scenario5
                             .SetOperand(new[] { 12, 16, 24, 36 })
                             .Build())
                         .AddCondition(x2 =>
+                            x2.AsValued(BestServerConditions.Memory)
+                            .OfDataType<IEnumerable<int>>()
+                            .WithComparisonOperator(Operators.NotIn)
+                            .SetOperand(new[] { 4, 8 })
+                            .Build())
+                        .AddCondition(x2 =>
                             x2.AsValued(BestServerConditions.StoragePartionable)
                             .OfDataType<IEnumerable<bool>>()
                             .WithComparisonOperator(Operators.In)

--- a/tests/Rules.Framework.WebUI.Tests/Rules.Framework.WebUI.Tests.csproj
+++ b/tests/Rules.Framework.WebUI.Tests/Rules.Framework.WebUI.Tests.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="Rules.Framework" Version="1.7.3" />
+    <PackageReference Include="Rules.Framework" Version="1.7.4" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
## Description

Update rules.framework NuGet package version in order to use the operator.NotIn and updated integration tests (#112)

## Change checklist

- [x] Code follows the [code rules guidelines](../CONTRIBUTING.md#code-rules) of this project
- [x] Commit messages follow the [commit rules](../CONTRIBUTING.md#commit-rules) of this project
- [x] I have self-reviewed my changes before submitting this pull request
- [x] I have covered new/changed code with new tests and/or adjusted existent ones
- [ ] I have made changes necessary to update the documentation accordingly

Please also check the [_I want to contribute_](../CONTRIBUTING.md#i-want-to-contribute) guidelines and make sure you have done accordingly.

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)