### PR TITLE
fix: fixed the web ui filter rules by value (content)

### DIFF
--- a/samples/Rules.Framework.WebUI.Sample/Engine/RulesEngineProvider.cs
+++ b/samples/Rules.Framework.WebUI.Sample/Engine/RulesEngineProvider.cs
@@ -19,7 +19,7 @@ namespace Rules.Framework.WebUI.Sample.Engine
                     .WithContentType<ContentTypes>()
                     .WithConditionType<ConditionTypes>()
                     .SetInMemoryDataSource()
-                    .Configure(c => c.PriotityCriteria = PriorityCriterias.BottommostRuleWins)
+                    .Configure(c => c.PriotityCriteria = PriorityCriterias.TopmostRuleWins)
                     .Build();
 
                 await rulesBuilder.BuildAsync(rulesEngine).ConfigureAwait(false);

--- a/samples/Rules.Framework.WebUI.Sample/Rules/RulesRandomFactory.cs
+++ b/samples/Rules.Framework.WebUI.Sample/Rules/RulesRandomFactory.cs
@@ -43,7 +43,7 @@ namespace Rules.Framework.WebUI.Sample.Rules
                                      RuleBuilder
                              .NewRule<ContentTypes, ConditionTypes>()
                              .WithName($"Multi rule for test {contentTypes} {value}")
-                             .WithContent(contentTypes, $"Value {contentTypes} {value}")
+                             .WithContent(contentTypes, new { Value = value })
                              .WithDatesInterval(dateBegin, dateEnd)
                              .WithCondition(cnb => cnb.AsComposed()
                                     .WithLogicalOperator(LogicalOperators.Or)
@@ -51,6 +51,11 @@ namespace Rules.Framework.WebUI.Sample.Rules
                                             .AsValued(ConditionTypes.RoyalNumber).OfDataType<int>()
                                             .WithComparisonOperator(Operators.Equal)
                                             .SetOperand(7)
+                                            .Build())
+                                        .AddCondition(condition => condition
+                                            .AsValued(ConditionTypes.SumAll).OfDataType<int>()
+                                            .WithComparisonOperator(Operators.Equal)
+                                            .SetOperand(9)
                                             .Build())
                                         .AddCondition(condition => condition.AsComposed()
                                             .WithLogicalOperator(LogicalOperators.And)
@@ -73,8 +78,8 @@ namespace Rules.Framework.WebUI.Sample.Rules
                                                     .Build())
                                                 .AddCondition(sub => sub
                                                     .AsValued(ConditionTypes.SumAll).OfDataType<string>()
-                                                    .WithComparisonOperator(Operators.EndsWith)
-                                                    .SetOperand("150")
+                                                    .WithComparisonOperator(Operators.NotEqual)
+                                                    .SetOperand(string.Empty)
                                                     .Build())
                                             .Build())
                                         .Build())

--- a/src/Rules.Framework.WebUI/Dto/ContentTypeDto.cs
+++ b/src/Rules.Framework.WebUI/Dto/ContentTypeDto.cs
@@ -2,6 +2,7 @@ namespace Rules.Framework.WebUI.Dto
 {
     internal sealed class ContentTypeDto
     {
+        public int Index { get; internal set; }
         public int ActiveRulesCount { get; internal set; }
         public string Name { get; internal set; }
         public int RulesCount { get; internal set; }

--- a/src/Rules.Framework.WebUI/Handlers/GetContentTypeHandler.cs
+++ b/src/Rules.Framework.WebUI/Handlers/GetContentTypeHandler.cs
@@ -33,7 +33,7 @@ namespace Rules.Framework.WebUI.Handlers
                 var contents = this.genericRulesEngineAdapter.GetContentTypes();
 
                 var contentTypes = new List<ContentTypeDto>();
-
+                var index = 0;
                 foreach (var identifier in contents.Select(c => c.Identifier))
                 {
                     var genericContentType = new GenericContentType { Identifier = identifier };
@@ -46,10 +46,12 @@ namespace Rules.Framework.WebUI.Handlers
 
                     contentTypes.Add(new ContentTypeDto
                     {
+                        Index = index,
                         Name = identifier,
                         ActiveRulesCount = genericRules.Count(IsActive),
                         RulesCount = genericRules.Count()
                     });
+                    index++;
                 }
 
                 await this.WriteResponseAsync(httpResponse, contentTypes, (int)HttpStatusCode.OK).ConfigureAwait(false);

--- a/src/Rules.Framework.WebUI/index.html
+++ b/src/Rules.Framework.WebUI/index.html
@@ -466,7 +466,13 @@
                 html += '<ul class="nested">';
 
                 html += '<li>' + node.operator + '</li>';
-                html += '<li>' + node.operand + '</li>';
+
+                let operand = node.operand;
+                if ($.trim(operand) == '') {
+                    operand = 'Empty';
+                }
+
+                html += '<li>' + operand + '</li>';
 
                 html += '</ul></li>';
 

--- a/src/Rules.Framework.WebUI/index.html
+++ b/src/Rules.Framework.WebUI/index.html
@@ -164,7 +164,7 @@
                                     </div>
 
                                     <div class="col-md-3">
-                                        <label for="ruleValueSearch" class="col-form-label-sm">Value</label>
+                                        <label for="ruleValueSearch" class="col-form-label-sm">Content</label>
                                         <input class="form-control form-control-sm" id="ruleValueSearch" />
                                     </div>
 
@@ -389,63 +389,53 @@
         }
 
         function setStringView(node) {
-            let html = recursiveStringView(node, null, 0);
+            let html = recursiveStringView(node, null, false, 0);
 
             return html;
         }
-
-        function recursiveStringView(node, logicalOperator, tabs)
-        {
-            let html = '';
-            let tabsLeft = 1;
-            let tabsLeftChild = 1;
+        function recursiveStringView(node, logicalOperator, isFirst, tabsLeft) {
+            let html = '';                        
             if (!node) {
                 return html;
             }
 
             if (node.conditionTypeName) {
-                if (logicalOperator) {
-                    if (tabs) {
-                        tabsLeft = 4 * tabs;
-                    }
-
-                    html += '<br/><span class="conditions-tab" style="--tab-left: ' + tabsLeft + 'em"><b>' + logicalOperator + '</b></span> ';
+                if (logicalOperator && !isFirst) {
+                    html += '<br/><span class="conditions-tab" style="--tab-left: ' + (4 * tabsLeft) + 'em"><b>' + logicalOperator + '</b></span> ';
                 }
+                else
+                {
+                    html += '<span class="conditions-tab" style="--tab-left: ' + (4 * tabsLeft) + 'em"></span> ';
+                }
+                
+                html += '<i>' + node.conditionTypeName + '</i>';
 
-                html += '<i>' + node.conditionTypeName + '</i> (';
+                html += ' <span style="text-decoration:underline">' + node.operator + '</span> ';
 
-                html += node.operator;
-                html += ' ' + node.operand;
-
-                html += ')';
+                let operand = node.operand;
+                if ($.trim(operand) == '') {
+                    operand = 'Empty';
+                }
+                html += ' ' + operand;
 
                 return html;
             }
 
             if (node.logicalOperator) {
-                if (tabs) {
-                    tabsLeft = 4 * tabs;
-                    html += '<br/>';
-                }
-
-                html += '<span class="conditions-tab" style="--tab-left: ' + tabsLeft + 'em"> <b>' + node.logicalOperator + '</b></span>';
-
-
                 if (node.childConditionNodes) {
-                    tabs++;
-                    if (tabs) {
-                        tabsLeftChild = 4 * tabs;
+                    if (logicalOperator && !isFirst) {                        
+                        html += ' <br/><span class="conditions-tab" style="--tab-left: ' + (4 * tabsLeft) + 'em"><b>' + logicalOperator + '</b> (<br/>';
+                        tabsLeft++;
                     }
-
-                    html += ' (<br/><span class="conditions-tab" style="--tab-left: ' + tabsLeftChild + 'em">';
 
                     for (var i = 0; i < node.childConditionNodes.length; i++) {
-                        html += recursiveStringView(node.childConditionNodes[i], i > 0 ? node.logicalOperator : '', tabs);
+                        html += recursiveStringView(node.childConditionNodes[i], node.logicalOperator, i == 0, tabsLeft);
                     }
 
-                    html += '<br/></span><span class="conditions-tab" style="--tab-left: ' + tabsLeft + 'em">)</span>';
+                    if (logicalOperator && !isFirst) {
+                        html += '<br/></span><span class="conditions-tab" style="--tab-left: ' + (4 * (tabsLeft-1)) + 'em">)</span>';
+                    }
                 }
-
                 return html;
             }
 
@@ -517,7 +507,7 @@
 
             if (ruleFilter.value) {
                 dataSource = dataSource.filter(function (r) {
-                    return r.value.toLowerCase().includes(ruleFilter.value.toLowerCase());
+                    return JSON.stringify(r.value).toLowerCase().includes(ruleFilter.value.toLowerCase());
                 });
             }
 
@@ -737,21 +727,21 @@
                 <div class="modal-body">
                     <ul class="nav nav-tabs" role="tablist">
                         <li class="nav-item" role="presentation">
-                            <a class="nav-link active" aria-current="page" data-bs-target="#string-tab-pane" data-bs-toggle="tab" href="#">String</a>
-                        </li>
-                        <li class="nav-item" role="presentation">
-                            <a class="nav-link" href="#" data-bs-target="#json-tab-pane" data-bs-toggle="tab">Json</a>
+                            <a class="nav-link active" aria-current="page" data-bs-target="#string-tab-pane" data-bs-toggle="tab" href="#">Pretty</a>
                         </li>
                         <li class="nav-item" role="presentation">
                             <a class="nav-link" href="#" data-bs-target="#tree-tab-pane" data-bs-toggle="tab">Tree</a>
+                        </li>
+                        <li class="nav-item" role="presentation">
+                            <a class="nav-link" href="#" data-bs-target="#json-tab-pane" data-bs-toggle="tab">Json</a>
                         </li>
                     </ul>
 
                     <div class="row"></div>
                     <div class="tab-content" id="myTabContent" style="max-height: 500px; overflow-y: auto; ">
                         <div class="tab-pane fade show active" id="string-tab-pane" role="tabpanel" aria-labelledby="string-tab" tabindex="0"></div>
-                        <div class="tab-pane fade" id="json-tab-pane" role="tabpanel" aria-labelledby="json-tab" tabindex="1"></div>
-                        <div class="tab-pane fade" id="tree-tab-pane" role="tabpanel" aria-labelledby="tree-tab" tabindex="2"></div>
+                        <div class="tab-pane fade" id="tree-tab-pane" role="tabpanel" aria-labelledby="tree-tab" tabindex="1"></div>
+                        <div class="tab-pane fade" id="json-tab-pane" role="tabpanel" aria-labelledby="json-tab" tabindex="2"></div>
                     </div>
 
                 </div>

--- a/src/Rules.Framework.WebUI/index.html
+++ b/src/Rules.Framework.WebUI/index.html
@@ -110,9 +110,17 @@
                             </legend>
                             <div class="collapse show" id="filterContentTypes">
                                 <form novalidate>
-                                    <div class="col-md-4">
-                                        <label for="contentTypeSearch" class="col-form-label-sm">Name</label>
-                                        <input class="form-control form-control-sm" id="contentTypeSearch" />
+                                    <div class="col-md-12" style="display: flex; align-items: flex-end;">
+                                        <div class="col-md-5" style="margin-right: 12px;">
+                                            <label for="contentTypeSearch" class="col-form-label-sm">Name</label>
+                                            <input class="form-control form-control-sm" id="contentTypeSearch" />
+                                        </div>
+                                        <div>
+                                            <div class="form-check form-switch">
+                                                <input class="form-check-input" type="checkbox" role="switch" id="contentTypeOnlyWithRules">
+                                                <label class="form-check-label" for="contentTypeOnlyWithRules"> Show only with rules</label>
+                                            </div>
+                                        </div>
                                     </div>
                                 </form>
                             </div>
@@ -192,6 +200,12 @@
                                     </button>
                                     <ul class="dropdown-menu">
                                         <li><a class="dropdown-item download" href="#"><span class="glyphicon glyphicon-cloud-download"></span> Export JSON</a></li>
+                                        <li style="width: 200px; padding: 5px 5px 5px 5px;">
+                                            <div class="form-check form-switch">
+                                                <input class="form-check-input" type="checkbox" role="switch" id="conditionsAsColumn">
+                                                <label class="form-check-label" for="conditionsAsColumn"> Condition as column</label>
+                                            </div>
+                                        </li>
                                     </ul>
                                 </div>
                             </div>
@@ -201,12 +215,13 @@
                                 <thead style="border-bottom: 2px solid currentcolor;">
                                     <tr>
                                         <th scope="col" width="2%">Priority</th>
-                                        <th scope="col" width="30%">Name</th>
-                                        <th scope="col" width="16%" nowrap style="text-align: center;">Date Begin</th>
-                                        <th scope="col" width="16%" nowrap style="text-align: center;">Date End</th>
-                                        <th scope="col" width="25%">Content</th>
-                                        <th scope="col" width="6%" style="text-align: center;">Status</th>
-                                        <th scope="col" width="5%" style="text-align: center;">Conditions</th>
+                                        <th scope="col" width="20%">Name</th>
+                                        <th scope="col" width="10%" nowrap style="text-align: center;">Date Begin</th>
+                                        <th scope="col" width="10%" nowrap style="text-align: center;">Date End</th>
+                                        <th scope="col" width="20%">Content</th>
+                                        <th scope="col" width="5%" style="text-align: center;">Status</th>
+                                        <th scope="col" width="5%" style="text-align: center;" class="conditionsAsColumnButton">Conditions</th>
+                                        <th scope="col" width="33%" style="text-align: center; display:none;" class="conditionsAsColumnText">Conditions</th>
                                     </tr>
                                 </thead>
                                 <tbody id="rules_table">
@@ -236,6 +251,10 @@
         priority = '';
         conditions = [];
         pageSize = 10;
+        contentTypesFilter = {
+            name: '',
+            onlyWithRules: false
+        };
         ruleFilter = {
             status: '',
             name: '',
@@ -243,6 +262,9 @@
         };
 
         function setContentTypesPagination(dataSource) {
+
+            dataSource = applyContentTypesFilter(dataSource);
+
             $('#contentTypes_pagination').pagination({
                 dataSource: dataSource,
                 pageSize: pageSize,
@@ -270,6 +292,7 @@
 
         function populateRules(dataSource) {
             let trHTML = '';
+            const conditionsAsColumnChecked = $('#conditionsAsColumn').prop('checked');
             $.each(dataSource, function (_, item) {
 
                 let labelColor = '';
@@ -304,14 +327,15 @@
                 trHTML += item.status;
                 trHTML += ' <span class="' + icon + '"></span> '
                 trHTML += '</span></td>';
-                trHTML += '<td nowrap style="text-align: center;"><button style="font-size:.875rem" type="button" class="btn btn-dark conditions"  ';
+                trHTML += '<td nowrap style="text-align: center;" class="conditionsAsColumnButton"><button type="button" class="btn btn-dark conditions textSize"  ';
                 trHTML += 'data-bs-toggle="modal" data-bs-target="#conditionsModal" title="Conditions" id="b' + item.priority + '">';
                 trHTML += '<span class="glyphicon glyphicon-tasks" id="' + item.priority + '"></span>';
-                trHTML += '</button></td></tr>';
+                trHTML += '</button></td>';
+                trHTML += '<td class="conditionsAsColumnText" style="display:none;">' + setStringView(item.conditions) + '</td></tr>';
 
             });
             $('#rules_table').html(trHTML);
-
+            $('#conditionsAsColumn').prop('checked', conditionsAsColumnChecked).change()
             $("#loading").hide();
             setConditionsEvent();
         }
@@ -319,8 +343,8 @@
         function populateContentTypes(dataSource)
         {
             let trHTML = '';
-            $.each(dataSource, function (i, item) {
-                trHTML += '<tr><th scope="row">' + i + ' </th><td>' + item.name + '</td>';
+            $.each(dataSource, function (_, item) {
+                trHTML += '<tr><th scope="row">' + item.index + ' </th><td>' + item.name + '</td>';
                 trHTML += '<td style="text-align: center;"><span class="badge bg-success" style="font-size:1em!important; color: #1c6c09 !important;background-color: #d9fbd0 !important;">' + item.activeRulesCount + '<span></td>';
                 trHTML += '<td style="text-align: center;"><span class="badge bg-primary" style="font-size:1em!important; color: #373b3e !important;background-color: #cdced7 !important;">' + item.rulesCount + '<span></td>';
                 trHTML += '<td style="text-align: center;"><button style="font-size:.875rem" type="button" class="btn btn-dark rules"  ';
@@ -549,7 +573,43 @@
 
         }
 
+        function applyContentTypesFilter(dataSource) {
+
+            if (contentTypesFilter.name) {
+                dataSource = dataSource.filter(function (r) {
+                    return r.name.toLowerCase().includes(contentTypesFilter.name.toLowerCase());
+                });
+            }
+            dataSource = dataSource.filter(function (r) {
+                return !contentTypesFilter.onlyWithRules || (contentTypesFilter.onlyWithRules && r.rulesCount > 0);
+            });
+
+            return dataSource;
+        }
+
         $(document).ready(() => {
+            $('#conditionsAsColumn').on('change', function (e) {
+                const checked = $(this).prop('checked');
+
+                if (checked) {
+                    $('.conditionsAsColumnText').show();
+                    $('.conditionsAsColumnButton').hide();
+                    return;
+                }
+
+                $('.conditionsAsColumnButton').show();
+                $('.conditionsAsColumnText').hide();
+
+            });
+
+            $('#contentTypeOnlyWithRules').on('change', function (e) {
+                const checked = $(this).prop('checked');
+
+                contentTypesFilter.onlyWithRules = checked;
+
+                setContentTypesPagination(contentTypes);
+            });
+
             $('#ruleStatusesSelect').on('change', function (e) {
                 ruleFilter.status = $(this).children("option:selected").val();
                 setRulesPagination(rules);
@@ -567,16 +627,9 @@
 
             $('#contentTypeSearch').on('input', function (e) {
                 const contentTypeValue = $(this).val();
-                if (contentTypeValue) {
-                    let contentTypesFiltered = contentTypes.filter(function (r) {
-                        return r.name.toLowerCase().includes(contentTypeValue.toLowerCase());
-                    });
 
-                    setContentTypesPagination(contentTypesFiltered);
-                    return;
-                }
+                contentTypesFilter.name = contentTypeValue;
                 setContentTypesPagination(contentTypes);
-
             });
 
             $('.download').on('click', function () {
@@ -629,11 +682,12 @@
                     }
                 });
 
-                if (d.currentTarget.id == "contentTypes") {
+                if (d.currentTarget.id == 'contentTypes') {
                     setContentTypesPagination([]);
-                    $("#loading").show();
+                    $('#loading').show();
                     $.ajax({
-                        url: "api/v1/contentTypes",
+                        type: 'get',
+                        url: 'api/v1/contentTypes',
                         success: function (response) {
                             contentTypes = response;
                             setContentTypesPagination(response)

--- a/src/Rules.Framework.WebUI/index.html
+++ b/src/Rules.Framework.WebUI/index.html
@@ -118,7 +118,9 @@
                                         <div>
                                             <div class="form-check form-switch">
                                                 <input class="form-check-input" type="checkbox" role="switch" id="contentTypeOnlyWithRules">
-                                                <label class="form-check-label" for="contentTypeOnlyWithRules"> Show only with rules</label>
+                                                <label class="form-check-label" for="contentTypeOnlyWithRules"> Show only content types with rules
+                                                    
+                                                </label>
                                             </div>
                                         </div>
                                     </div>


### PR DESCRIPTION
## Description

All of these changes are on Rules.Framework Web UI
- fixed #120 
- a better way to show conditions in string format (pretty)
- changed rules "value" labels to "content"
- condition operand is a string empty 


## Change checklist

- [x] Code follows the [code rules guidelines](../CONTRIBUTING.md#code-rules) of this project
- [x] Commit messages follow the [commit rules](../CONTRIBUTING.md#commit-rules) of this project
- [x] I have self-reviewed my changes before submitting this pull request
- [ ] I have covered new/changed code with new tests and/or adjusted existent ones
- [ ] I have made changes necessary to update the documentation accordingly

Please also check the [_I want to contribute_](../CONTRIBUTING.md#i-want-to-contribute) guidelines and make sure you have done accordingly.

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)