### PR TITLE
Set the Condition parameterless constructor obsolete

### DIFF
--- a/samples/Rules.Framework.InMemory.Sample/Engine/RulesService.cs
+++ b/samples/Rules.Framework.InMemory.Sample/Engine/RulesService.cs
@@ -22,7 +22,7 @@ namespace Rules.Framework.InMemory.Sample.Engine
             IDictionary<ConditionTypes, object> conditions)
         {
             var rulesConditions = (conditions is null) ? new Condition<ConditionTypes>[] { } :
-                conditions.Select(x => new Condition<ConditionTypes> { Type = x.Key, Value = x.Value })
+                conditions.Select(x => new Condition<ConditionTypes>(x.Key, x.Value))
                 .ToArray();
 
             var rulesEngine = await

--- a/src/Rules.Framework/Builder/FluentComposedConditionNodeBuilder.cs
+++ b/src/Rules.Framework/Builder/FluentComposedConditionNodeBuilder.cs
@@ -31,8 +31,15 @@ namespace Rules.Framework.Builder
             return new ComposedConditionNode<TConditionType>(this.logicalOperator, this.conditions);
         }
 
+        public IFluentComposedConditionNodeBuilder<TConditionType> Condition(IConditionNode<TConditionType> valueConditionNode)
+        {
+            this.conditions.Add(valueConditionNode);
+
+            return this;
+        }
+
         public IFluentComposedConditionNodeBuilder<TConditionType> Or(
-            Func<IFluentComposedConditionNodeBuilder<TConditionType>, IFluentComposedConditionNodeBuilder<TConditionType>> conditionFunc)
+                    Func<IFluentComposedConditionNodeBuilder<TConditionType>, IFluentComposedConditionNodeBuilder<TConditionType>> conditionFunc)
         {
             var composedConditionNode = ConditionNodeFactory.CreateComposedNode(LogicalOperators.Or, conditionFunc);
 
@@ -45,13 +52,6 @@ namespace Rules.Framework.Builder
         {
             var valueConditionNode = ConditionNodeFactory.CreateValueNode(conditionType, condOperator, operand);
 
-            this.conditions.Add(valueConditionNode);
-
-            return this;
-        }
-
-        public IFluentComposedConditionNodeBuilder<TConditionType> Value(IConditionNode<TConditionType> valueConditionNode)
-        {
             this.conditions.Add(valueConditionNode);
 
             return this;

--- a/src/Rules.Framework/Builder/FluentComposedConditionNodeBuilder.cs
+++ b/src/Rules.Framework/Builder/FluentComposedConditionNodeBuilder.cs
@@ -31,9 +31,9 @@ namespace Rules.Framework.Builder
             return new ComposedConditionNode<TConditionType>(this.logicalOperator, this.conditions);
         }
 
-        public IFluentComposedConditionNodeBuilder<TConditionType> Condition(IConditionNode<TConditionType> valueConditionNode)
+        public IFluentComposedConditionNodeBuilder<TConditionType> Condition(IConditionNode<TConditionType> conditionNode)
         {
-            this.conditions.Add(valueConditionNode);
+            this.conditions.Add(conditionNode);
 
             return this;
         }

--- a/src/Rules.Framework/Builder/IFluentComposedConditionNodeBuilder.cs
+++ b/src/Rules.Framework/Builder/IFluentComposedConditionNodeBuilder.cs
@@ -24,6 +24,12 @@ namespace Rules.Framework.Builder
         IConditionNode<TConditionType> Build();
 
         /// <summary>
+        /// Adds a condition to the fluent condition node builder.
+        /// </summary>
+        /// <param name="conditionNode">The condition node.</param>
+        IFluentComposedConditionNodeBuilder<TConditionType> Condition(IConditionNode<TConditionType> conditionNode);
+
+        /// <summary>
         /// Adds a composed Or condition to the fluent condition node builder.
         /// </summary>
         /// <param name="conditionFunc">The function containing the logic for the new condition.</param>
@@ -39,11 +45,5 @@ namespace Rules.Framework.Builder
         /// <param name="operand">The condition operand.</param>
         /// <returns></returns>
         IFluentComposedConditionNodeBuilder<TConditionType> Value<TDataType>(TConditionType conditionType, Operators condOperator, TDataType operand);
-
-        /// <summary>
-        /// Adds a value condition to the fluent condition node builder.
-        /// </summary>
-        /// <param name="valueConditionNode">The value condition node.</param>
-        IFluentComposedConditionNodeBuilder<TConditionType> Value(IConditionNode<TConditionType> valueConditionNode);
     }
 }

--- a/src/Rules.Framework/Builder/IFluentComposedConditionNodeBuilder.cs
+++ b/src/Rules.Framework/Builder/IFluentComposedConditionNodeBuilder.cs
@@ -10,7 +10,7 @@ namespace Rules.Framework.Builder
     public interface IFluentComposedConditionNodeBuilder<TConditionType>
     {
         /// <summary>
-        /// Adds a composed And condition to the fluent condition node builder.
+        /// Adds a And composed condition to the fluent condition node builder.
         /// </summary>
         /// <param name="conditionFunc">The function containing the logic for the new condition.</param>
         /// <returns></returns>
@@ -24,13 +24,13 @@ namespace Rules.Framework.Builder
         IConditionNode<TConditionType> Build();
 
         /// <summary>
-        /// Adds a condition to the fluent condition node builder.
+        /// Adds a Condition to the fluent condition node builder.
         /// </summary>
         /// <param name="conditionNode">The condition node.</param>
         IFluentComposedConditionNodeBuilder<TConditionType> Condition(IConditionNode<TConditionType> conditionNode);
 
         /// <summary>
-        /// Adds a composed Or condition to the fluent condition node builder.
+        /// Adds a Or composed condition to the fluent condition node builder.
         /// </summary>
         /// <param name="conditionFunc">The function containing the logic for the new condition.</param>
         /// <returns></returns>
@@ -38,7 +38,7 @@ namespace Rules.Framework.Builder
             Func<IFluentComposedConditionNodeBuilder<TConditionType>, IFluentComposedConditionNodeBuilder<TConditionType>> conditionFunc);
 
         /// <summary>
-        /// Adds a value condition to the fluent condition node builder.
+        /// Adds a Value condition to the fluent condition node builder.
         /// </summary>
         /// <param name="conditionType">The condition type.</param>
         /// <param name="condOperator">The condition operator.</param>

--- a/src/Rules.Framework/Builder/IRootConditionNodeBuilder.cs
+++ b/src/Rules.Framework/Builder/IRootConditionNodeBuilder.cs
@@ -10,7 +10,7 @@ namespace Rules.Framework.Builder
     public interface IRootConditionNodeBuilder<TConditionType>
     {
         /// <summary>
-        /// Sets a root And condition for the condition node builder.
+        /// Sets a root And condition to the condition node builder.
         /// </summary>
         /// <param name="conditionFunc">The function containing the logic for the root condition.</param>
         /// <returns></returns>
@@ -18,7 +18,13 @@ namespace Rules.Framework.Builder
             Func<IFluentComposedConditionNodeBuilder<TConditionType>, IFluentComposedConditionNodeBuilder<TConditionType>> conditionFunc);
 
         /// <summary>
-        /// Sets a root Or condition for the condition node builder.
+        /// Sets a condition to the root condition node builder.
+        /// </summary>
+        /// <param name="conditionNode">The condition node.</param>
+        IConditionNode<TConditionType> Condition(IConditionNode<TConditionType> conditionNode);
+
+        /// <summary>
+        /// Sets a root Or condition to the condition node builder.
         /// </summary>
         /// <param name="conditionFunc">The function containing the logic for the root condition.</param>
         /// <returns></returns>
@@ -26,18 +32,12 @@ namespace Rules.Framework.Builder
             Func<IFluentComposedConditionNodeBuilder<TConditionType>, IFluentComposedConditionNodeBuilder<TConditionType>> conditionFunc);
 
         /// <summary>
-        /// Sets a value condition for the root condition node builder.
+        /// Sets a value condition to the root condition node builder.
         /// </summary>
         /// <param name="conditionType">The condition type.</param>
         /// <param name="condOperator">The condition operator.</param>
         /// <param name="operand">The condition operand.</param>
         /// <returns></returns>
         IConditionNode<TConditionType> Value<TDataType>(TConditionType conditionType, Operators condOperator, TDataType operand);
-
-        /// <summary>
-        /// Sets a value condition to the fluent condition node builder.
-        /// </summary>
-        /// <param name="valueConditionNode">The value condition node.</param>
-        IConditionNode<TConditionType> Value(IConditionNode<TConditionType> valueConditionNode);
     }
 }

--- a/src/Rules.Framework/Builder/IRootConditionNodeBuilder.cs
+++ b/src/Rules.Framework/Builder/IRootConditionNodeBuilder.cs
@@ -10,7 +10,7 @@ namespace Rules.Framework.Builder
     public interface IRootConditionNodeBuilder<TConditionType>
     {
         /// <summary>
-        /// Sets a root And condition to the condition node builder.
+        /// Sets a And composed condition to the root condition node builder.
         /// </summary>
         /// <param name="conditionFunc">The function containing the logic for the root condition.</param>
         /// <returns></returns>
@@ -18,13 +18,13 @@ namespace Rules.Framework.Builder
             Func<IFluentComposedConditionNodeBuilder<TConditionType>, IFluentComposedConditionNodeBuilder<TConditionType>> conditionFunc);
 
         /// <summary>
-        /// Sets a condition to the root condition node builder.
+        /// Sets a Condition to the root condition node builder.
         /// </summary>
         /// <param name="conditionNode">The condition node.</param>
         IConditionNode<TConditionType> Condition(IConditionNode<TConditionType> conditionNode);
 
         /// <summary>
-        /// Sets a root Or condition to the condition node builder.
+        /// Sets a Or composed condition to the root condition node builder.
         /// </summary>
         /// <param name="conditionFunc">The function containing the logic for the root condition.</param>
         /// <returns></returns>
@@ -32,7 +32,7 @@ namespace Rules.Framework.Builder
             Func<IFluentComposedConditionNodeBuilder<TConditionType>, IFluentComposedConditionNodeBuilder<TConditionType>> conditionFunc);
 
         /// <summary>
-        /// Sets a value condition to the root condition node builder.
+        /// Sets a Value condition to the root condition node builder.
         /// </summary>
         /// <param name="conditionType">The condition type.</param>
         /// <param name="condOperator">The condition operator.</param>

--- a/src/Rules.Framework/Builder/RootConditionNodeBuilder.cs
+++ b/src/Rules.Framework/Builder/RootConditionNodeBuilder.cs
@@ -11,8 +11,13 @@ namespace Rules.Framework.Builder
             return ConditionNodeFactory.CreateComposedNode(LogicalOperators.And, conditionFunc);
         }
 
+        public IConditionNode<TConditionType> Condition(IConditionNode<TConditionType> conditionNode)
+        {
+            return conditionNode;
+        }
+
         public IConditionNode<TConditionType> Or(
-            Func<IFluentComposedConditionNodeBuilder<TConditionType>, IFluentComposedConditionNodeBuilder<TConditionType>> conditionFunc)
+                    Func<IFluentComposedConditionNodeBuilder<TConditionType>, IFluentComposedConditionNodeBuilder<TConditionType>> conditionFunc)
         {
             return ConditionNodeFactory.CreateComposedNode(LogicalOperators.Or, conditionFunc);
         }
@@ -21,11 +26,6 @@ namespace Rules.Framework.Builder
             TConditionType conditionType, Operators condOperator, TDataType operand)
         {
             return ConditionNodeFactory.CreateValueNode(conditionType, condOperator, operand);
-        }
-
-        public IConditionNode<TConditionType> Value(IConditionNode<TConditionType> valueConditionNode)
-        {
-            return valueConditionNode;
         }
     }
 }

--- a/src/Rules.Framework/Condition.cs
+++ b/src/Rules.Framework/Condition.cs
@@ -1,5 +1,7 @@
 namespace Rules.Framework
 {
+    using System;
+
     /// <summary>
     /// Defines a condition to filter rules.
     /// </summary>
@@ -22,6 +24,7 @@ namespace Rules.Framework
         /// <summary>
         /// Creates a Condition.
         /// </summary>
+        [Obsolete("Please use the constructor with parameters instead.")]
         public Condition()
         {
         }

--- a/src/Rules.Framework/Extensions/GenericSearchArgsExtensions.cs
+++ b/src/Rules.Framework/Extensions/GenericSearchArgsExtensions.cs
@@ -21,10 +21,10 @@ namespace Rules.Framework.Extensions
                 return new SearchArgs<TContentType, TConditionType>(contentType, genericSearchArgs.DateBegin, genericSearchArgs.DateEnd, genericSearchArgs.Active.Value)
                 {
                     Conditions = genericSearchArgs.Conditions.Select(condition => new Condition<TConditionType>
-                    {
-                        Value = condition.Value,
-                        Type = (TConditionType)Enum.Parse(typeof(TConditionType), condition.Type.Identifier)
-                    }).ToList(),
+                    (
+                        (TConditionType)Enum.Parse(typeof(TConditionType), condition.Type.Identifier),
+                        condition.Value
+                    )).ToList(),
                     ExcludeRulesWithoutSearchConditions = genericSearchArgs.ExcludeRulesWithoutSearchConditions
                 };
             }
@@ -32,10 +32,10 @@ namespace Rules.Framework.Extensions
             var searchArgs = new SearchArgs<TContentType, TConditionType>(contentType, genericSearchArgs.DateBegin, genericSearchArgs.DateEnd)
             {
                 Conditions = genericSearchArgs.Conditions.Select(condition => new Condition<TConditionType>
-                {
-                    Value = condition.Value,
-                    Type = (TConditionType)Enum.Parse(typeof(TConditionType), condition.Type.Identifier)
-                }).ToList(),
+                    (
+                        (TConditionType)Enum.Parse(typeof(TConditionType), condition.Type.Identifier),
+                        condition.Value
+                    )).ToList(),
                 ExcludeRulesWithoutSearchConditions = genericSearchArgs.ExcludeRulesWithoutSearchConditions
             };
 

--- a/tests/Rules.Framework.IntegrationTests.Common/Scenarios/Scenario6/Scenario6Data.cs
+++ b/tests/Rules.Framework.IntegrationTests.Common/Scenarios/Scenario6/Scenario6Data.cs
@@ -3,12 +3,14 @@ namespace Rules.Framework.BenchmarkTests.Tests.Benchmark1
     using System;
     using System.Collections.Generic;
     using Rules.Framework.BenchmarkTests.Tests;
-    using Rules.Framework.Builder;
     using Rules.Framework.Core;
 
     public class Scenario6Data : IScenarioData<ContentTypes, ConditionTypes>
     {
-        public IEnumerable<Condition<ConditionTypes>> Conditions => new[] { new Condition<ConditionTypes> { Type = ConditionTypes.StringCondition, Value = "Let's benchmark this!" } };
+        public IEnumerable<Condition<ConditionTypes>> Conditions => new[]
+        {
+            new Condition<ConditionTypes>(ConditionTypes.StringCondition, "Let's benchmark this!")
+        };
 
         public DateTime MatchDate => DateTime.Parse("2022-10-01");
 

--- a/tests/Rules.Framework.IntegrationTests.Common/Scenarios/Scenario7/Scenario7Data.cs
+++ b/tests/Rules.Framework.IntegrationTests.Common/Scenarios/Scenario7/Scenario7Data.cs
@@ -3,7 +3,6 @@ namespace Rules.Framework.BenchmarkTests.Tests.Benchmark2
     using System;
     using System.Collections.Generic;
     using Rules.Framework;
-    using Rules.Framework.Builder;
     using Rules.Framework.Core;
 
     public class Scenario7Data : IScenarioData<ContentTypes, ConditionTypes>

--- a/tests/Rules.Framework.IntegrationTests.Common/Scenarios/Scenario7/Scenario7Data.cs
+++ b/tests/Rules.Framework.IntegrationTests.Common/Scenarios/Scenario7/Scenario7Data.cs
@@ -9,9 +9,9 @@ namespace Rules.Framework.BenchmarkTests.Tests.Benchmark2
     {
         public IEnumerable<Condition<ConditionTypes>> Conditions => new[]
         {
-            new Condition<ConditionTypes> { Type = ConditionTypes.Artist, Value = "Queen" },
-            new Condition<ConditionTypes> { Type = ConditionTypes.Lyrics, Value = "Is this the real life?\nIs this just fantasy?\nCaught in a landside,\nNo escape from reality" },
-            new Condition<ConditionTypes> { Type = ConditionTypes.ReleaseYear, Value = 1975 }
+            new Condition<ConditionTypes>(ConditionTypes.Artist, "Queen"),
+            new Condition<ConditionTypes>(ConditionTypes.Lyrics, "Is this the real life?\nIs this just fantasy?\nCaught in a landside,\nNo escape from reality" ),
+            new Condition<ConditionTypes>(ConditionTypes.ReleaseYear, 1975 )
         };
 
         public DateTime MatchDate => DateTime.Parse("2022-11-01");

--- a/tests/Rules.Framework.IntegrationTests.Common/Scenarios/Scenario8/Scenario8Data.RoyalFlush.cs
+++ b/tests/Rules.Framework.IntegrationTests.Common/Scenarios/Scenario8/Scenario8Data.RoyalFlush.cs
@@ -2,7 +2,6 @@ namespace Rules.Framework.BenchmarkTests.Tests.Benchmark3
 {
     using System;
     using System.Collections.Generic;
-    using Rules.Framework.Builder;
     using Rules.Framework.Core;
 
     public partial class Scenario8Data : IScenarioData<ContentTypes, ConditionTypes>
@@ -22,8 +21,8 @@ namespace Rules.Framework.BenchmarkTests.Tests.Benchmark3
                             .Value(ConditionTypes.QueenOfClubs, Operators.Equal, true)
                             .Value(ConditionTypes.KingOfClubs, Operators.Equal, true)
                             .Value(ConditionTypes.AceOfClubs, Operators.Equal, true)
+                            )
                         )
-                    )
                     .Build().Rule,
                 RuleBuilder.NewRule<ContentTypes, ConditionTypes>()
                     .WithName("Benchmark 3 - Royal flush of Diamonds: Ace, King, Queen, Jack, 10")
@@ -36,8 +35,8 @@ namespace Rules.Framework.BenchmarkTests.Tests.Benchmark3
                             .Value(ConditionTypes.QueenOfDiamonds, Operators.Equal, true)
                             .Value(ConditionTypes.KingOfDiamonds, Operators.Equal, true)
                             .Value(ConditionTypes.AceOfDiamonds, Operators.Equal, true)
+                            )
                         )
-                    )
                     .Build().Rule,
                 RuleBuilder.NewRule<ContentTypes, ConditionTypes>()
                     .WithName("Benchmark 3 - Royal flush of Hearts: Ace, King, Queen, Jack, 10")
@@ -50,8 +49,8 @@ namespace Rules.Framework.BenchmarkTests.Tests.Benchmark3
                             .Value(ConditionTypes.QueenOfHearts, Operators.Equal, true)
                             .Value(ConditionTypes.KingOfHearts, Operators.Equal, true)
                             .Value(ConditionTypes.AceOfHearts, Operators.Equal, true)
+                            )
                         )
-                    )
                     .Build().Rule,
                 RuleBuilder.NewRule<ContentTypes, ConditionTypes>()
                     .WithName("Benchmark 3 - Royal flush of Spades: Ace, King, Queen, Jack, 10")
@@ -64,8 +63,8 @@ namespace Rules.Framework.BenchmarkTests.Tests.Benchmark3
                             .Value(ConditionTypes.QueenOfSpades, Operators.Equal, true)
                             .Value(ConditionTypes.KingOfSpades, Operators.Equal, true)
                             .Value(ConditionTypes.AceOfSpades, Operators.Equal, true)
+                            )
                         )
-                    )
                     .Build().Rule,
             };
         }

--- a/tests/Rules.Framework.IntegrationTests.Common/Scenarios/Scenario8/Scenario8Data.Straight.cs
+++ b/tests/Rules.Framework.IntegrationTests.Common/Scenarios/Scenario8/Scenario8Data.Straight.cs
@@ -2,7 +2,6 @@ namespace Rules.Framework.BenchmarkTests.Tests.Benchmark3
 {
     using System;
     using System.Collections.Generic;
-    using Rules.Framework.Builder;
     using Rules.Framework.Core;
 
     public partial class Scenario8Data : IScenarioData<ContentTypes, ConditionTypes>
@@ -22,8 +21,8 @@ namespace Rules.Framework.BenchmarkTests.Tests.Benchmark3
                             .Value(ConditionTypes.NumberOfFours, Operators.GreaterThanOrEqual, 1)
                             .Value(ConditionTypes.NumberOfFives, Operators.GreaterThanOrEqual, 1)
                             .Value(ConditionTypes.NumberOfSixes, Operators.GreaterThanOrEqual, 1)
-                        )
-                    )
+                            )
+                            )
                     .Build().Rule,
                 RuleBuilder.NewRule<ContentTypes, ConditionTypes>()
                     .WithName("Benchmark 3 - Straight 7, 6, 5, 4, 3")
@@ -36,8 +35,8 @@ namespace Rules.Framework.BenchmarkTests.Tests.Benchmark3
                             .Value(ConditionTypes.NumberOfFives, Operators.GreaterThanOrEqual, 1)
                             .Value(ConditionTypes.NumberOfSixes, Operators.GreaterThanOrEqual, 1)
                             .Value(ConditionTypes.NumberOfSevens, Operators.GreaterThanOrEqual, 1)
-                        )
-                    )
+                            )
+                            )
                     .Build().Rule,
                 RuleBuilder.NewRule<ContentTypes, ConditionTypes>()
                     .WithName("Benchmark 3 - Straight 8, 7, 6, 5, 4")
@@ -50,8 +49,8 @@ namespace Rules.Framework.BenchmarkTests.Tests.Benchmark3
                             .Value(ConditionTypes.NumberOfSixes, Operators.GreaterThanOrEqual, 1)
                             .Value(ConditionTypes.NumberOfSevens, Operators.GreaterThanOrEqual, 1)
                             .Value(ConditionTypes.NumberOfEigths, Operators.GreaterThanOrEqual, 1)
-                        )
-                    )
+                            )
+                            )
                     .Build().Rule,
                 RuleBuilder.NewRule<ContentTypes, ConditionTypes>()
                     .WithName("Benchmark 3 - Straight 9, 8, 7, 6, 5")
@@ -64,8 +63,8 @@ namespace Rules.Framework.BenchmarkTests.Tests.Benchmark3
                             .Value(ConditionTypes.NumberOfSevens, Operators.GreaterThanOrEqual, 1)
                             .Value(ConditionTypes.NumberOfEigths, Operators.GreaterThanOrEqual, 1)
                             .Value(ConditionTypes.NumberOfNines, Operators.GreaterThanOrEqual, 1)
-                        )
-                    )
+                            )
+                            )
                     .Build().Rule,
                 RuleBuilder.NewRule<ContentTypes, ConditionTypes>()
                     .WithName("Benchmark 3 - Straight 10, 9, 8, 7, 6")
@@ -78,8 +77,8 @@ namespace Rules.Framework.BenchmarkTests.Tests.Benchmark3
                             .Value(ConditionTypes.NumberOfEigths, Operators.GreaterThanOrEqual, 1)
                             .Value(ConditionTypes.NumberOfNines, Operators.GreaterThanOrEqual, 1)
                             .Value(ConditionTypes.NumberOfTens, Operators.GreaterThanOrEqual, 1)
+                            )
                         )
-                    )
                     .Build().Rule,
                 RuleBuilder.NewRule<ContentTypes, ConditionTypes>()
                     .WithName("Benchmark 3 - Straight Jack, 10, 9, 8, 7")
@@ -92,8 +91,8 @@ namespace Rules.Framework.BenchmarkTests.Tests.Benchmark3
                             .Value(ConditionTypes.NumberOfNines, Operators.GreaterThanOrEqual, 1)
                             .Value(ConditionTypes.NumberOfTens, Operators.GreaterThanOrEqual, 1)
                             .Value(ConditionTypes.NumberOfJacks, Operators.GreaterThanOrEqual, 1)
+                            )
                         )
-                    )
                     .Build().Rule,
                 RuleBuilder.NewRule<ContentTypes, ConditionTypes>()
                     .WithName("Benchmark 3 - Straight Queen, Jack, 10, 9, 8")
@@ -106,8 +105,8 @@ namespace Rules.Framework.BenchmarkTests.Tests.Benchmark3
                             .Value(ConditionTypes.NumberOfTens, Operators.GreaterThanOrEqual, 1)
                             .Value(ConditionTypes.NumberOfJacks, Operators.GreaterThanOrEqual, 1)
                             .Value(ConditionTypes.NumberOfQueens, Operators.GreaterThanOrEqual, 1)
+                            )
                         )
-                    )
                     .Build().Rule,
                 RuleBuilder.NewRule<ContentTypes, ConditionTypes>()
                     .WithName("Benchmark 3 - Straight King, Queen, Jack, 10, 9")
@@ -120,8 +119,8 @@ namespace Rules.Framework.BenchmarkTests.Tests.Benchmark3
                             .Value(ConditionTypes.NumberOfJacks, Operators.GreaterThanOrEqual, 1)
                             .Value(ConditionTypes.NumberOfQueens, Operators.GreaterThanOrEqual, 1)
                             .Value(ConditionTypes.NumberOfKings, Operators.GreaterThanOrEqual, 1)
+                            )
                         )
-                    )
                     .Build().Rule,
             };
         }

--- a/tests/Rules.Framework.IntegrationTests.Common/Scenarios/Scenario8/Scenario8Data.cs
+++ b/tests/Rules.Framework.IntegrationTests.Common/Scenarios/Scenario8/Scenario8Data.cs
@@ -10,16 +10,16 @@ namespace Rules.Framework.BenchmarkTests.Tests.Benchmark3
     {
         public IEnumerable<Condition<ConditionTypes>> Conditions => new[]
         {
-            new Condition<ConditionTypes> { Type = ConditionTypes.NumberOfKings, Value = 1 },
-            new Condition<ConditionTypes> { Type = ConditionTypes.NumberOfQueens, Value = 1 },
-            new Condition<ConditionTypes> { Type = ConditionTypes.NumberOfJacks, Value = 1 },
-            new Condition<ConditionTypes> { Type = ConditionTypes.NumberOfTens, Value = 1 },
-            new Condition<ConditionTypes> { Type = ConditionTypes.NumberOfNines, Value = 1 },
-            new Condition<ConditionTypes> { Type = ConditionTypes.KingOfClubs, Value = true },
-            new Condition<ConditionTypes> { Type = ConditionTypes.QueenOfDiamonds, Value = true },
-            new Condition<ConditionTypes> { Type = ConditionTypes.JackOfClubs, Value = true },
-            new Condition<ConditionTypes> { Type = ConditionTypes.TenOfHearts, Value = true },
-            new Condition<ConditionTypes> { Type = ConditionTypes.NineOfSpades, Value = true },
+            new Condition<ConditionTypes>(ConditionTypes.NumberOfKings, 1),
+            new Condition<ConditionTypes>(ConditionTypes.NumberOfQueens, 1 ),
+            new Condition<ConditionTypes>(ConditionTypes.NumberOfJacks, 1),
+            new Condition<ConditionTypes>(ConditionTypes.NumberOfTens, 1 ),
+            new Condition<ConditionTypes>(ConditionTypes.NumberOfNines, 1 ),
+            new Condition<ConditionTypes>(ConditionTypes.KingOfClubs, true ),
+            new Condition<ConditionTypes>(ConditionTypes.QueenOfDiamonds, true ),
+            new Condition<ConditionTypes>(ConditionTypes.JackOfClubs, true ),
+            new Condition<ConditionTypes>(ConditionTypes.TenOfHearts, true ),
+            new Condition<ConditionTypes>(ConditionTypes.NineOfSpades, true ),
         };
 
         public DateTime MatchDate => DateTime.Parse("2022-12-01");

--- a/tests/Rules.Framework.IntegrationTests/Scenarios/Scenario2/CarInsuranceAdvisorTests.cs
+++ b/tests/Rules.Framework.IntegrationTests/Scenarios/Scenario2/CarInsuranceAdvisorTests.cs
@@ -25,21 +25,9 @@ namespace Rules.Framework.IntegrationTests.Scenarios.Scenario2
             var expectedMatchDate = new DateTime(2020, 06, 01);
             var expectedConditions = new[]
             {
-                new Condition<ConditionTypes>
-                {
-                    Type = ConditionTypes.RepairCosts,
-                    Value = 800.00000m
-                },
-                new Condition<ConditionTypes>
-                {
-                    Type = ConditionTypes.RepairCostsCommercialValueRate,
-                    Value = 23.45602m
-                },
-                new Condition<ConditionTypes>
-                {
-                    Type = ConditionTypes.ClaimDescription,
-                    Value = "Driver A claims that Driver B appeared to be under the effect of alcohol."
-                }
+                new Condition<ConditionTypes>(ConditionTypes.RepairCosts,800.00000m),
+                new Condition<ConditionTypes>(ConditionTypes.RepairCostsCommercialValueRate,23.45602m),
+                new Condition<ConditionTypes>(ConditionTypes.ClaimDescription,"Driver A claims that Driver B appeared to be under the effect of alcohol.")
             };
 
             var serviceProvider = new ServiceCollection()
@@ -93,16 +81,8 @@ namespace Rules.Framework.IntegrationTests.Scenarios.Scenario2
             var expectedMatchDate = new DateTime(2018, 06, 01);
             var expectedConditions = new[]
             {
-                new Condition<ConditionTypes>
-                {
-                    Type = ConditionTypes.RepairCosts,
-                    Value = 800.00000m
-                },
-                new Condition<ConditionTypes>
-                {
-                    Type = ConditionTypes.RepairCostsCommercialValueRate,
-                    Value = 23.45602m
-                }
+                new Condition<ConditionTypes>(ConditionTypes.RepairCosts,800.00000m),
+                new Condition<ConditionTypes>(ConditionTypes.RepairCostsCommercialValueRate,23.45602m)
             };
 
             var serviceProvider = new ServiceCollection()
@@ -144,16 +124,8 @@ namespace Rules.Framework.IntegrationTests.Scenarios.Scenario2
             {
                 Conditions = new[]
                 {
-                    new Condition<ConditionTypes>
-                    {
-                        Type = ConditionTypes.RepairCosts,
-                        Value = 800.00000m
-                    },
-                    new Condition<ConditionTypes>
-                    {
-                        Type = ConditionTypes.RepairCostsCommercialValueRate,
-                        Value = 86.33m
-                    }
+                    new Condition<ConditionTypes>(ConditionTypes.RepairCosts, 800.00000m),
+                    new Condition<ConditionTypes>(ConditionTypes.RepairCostsCommercialValueRate, 86.33m)
                 },
                 ExcludeRulesWithoutSearchConditions = true
             };
@@ -196,11 +168,7 @@ namespace Rules.Framework.IntegrationTests.Scenarios.Scenario2
             {
                 Conditions = new[]
                 {
-                    new Condition<ConditionTypes>
-                    {
-                        Type = ConditionTypes.RepairCosts,
-                        Value = 1200.00000m
-                    }
+                    new Condition<ConditionTypes>(ConditionTypes.RepairCosts, 1200.00000m)
                 },
                 ExcludeRulesWithoutSearchConditions = false
             };
@@ -243,16 +211,8 @@ namespace Rules.Framework.IntegrationTests.Scenarios.Scenario2
             var expectedMatchDate = new DateTime(2018, 06, 01);
             var expectedConditions = new[]
             {
-                new Condition<ConditionTypes>
-                {
-                    Type = ConditionTypes.RepairCosts,
-                    Value = 800.00000m
-                },
-                new Condition<ConditionTypes>
-                {
-                    Type = ConditionTypes.RepairCostsCommercialValueRate,
-                    Value = 23.45602m
-                }
+                new Condition<ConditionTypes>(ConditionTypes.RepairCosts,800.00000m),
+                new Condition<ConditionTypes>(ConditionTypes.RepairCostsCommercialValueRate,23.45602m)
             };
 
             var serviceProvider = new ServiceCollection()

--- a/tests/Rules.Framework.IntegrationTests/Scenarios/Scenario3/BuildingSecuritySystemControlTests.cs
+++ b/tests/Rules.Framework.IntegrationTests/Scenarios/Scenario3/BuildingSecuritySystemControlTests.cs
@@ -6,7 +6,6 @@ namespace Rules.Framework.IntegrationTests.Scenarios.Scenario3
     using FluentAssertions;
     using Microsoft.Extensions.DependencyInjection;
     using Rules.Framework.IntegrationTests.Common.Scenarios.Scenario3;
-    using Rules.Framework.Providers.InMemory;
     using Xunit;
 
     public class BuildingSecuritySystemControlTests
@@ -22,21 +21,9 @@ namespace Rules.Framework.IntegrationTests.Scenarios.Scenario3
             var expectedMatchDate = new DateTime(2018, 06, 01);
             var expectedConditions = new[]
             {
-                new Condition<SecuritySystemConditions>
-                {
-                    Type = SecuritySystemConditions.TemperatureCelsius,
-                    Value = 100.0m
-                },
-                new Condition<SecuritySystemConditions>
-                {
-                    Type = SecuritySystemConditions.SmokeRate,
-                    Value = 55.0m
-                },
-                new Condition<SecuritySystemConditions>
-                {
-                    Type = SecuritySystemConditions.PowerStatus,
-                    Value = "Online"
-                }
+                new Condition<SecuritySystemConditions>(SecuritySystemConditions.TemperatureCelsius,100.0m),
+                new Condition<SecuritySystemConditions>(SecuritySystemConditions.SmokeRate,55),
+                new Condition<SecuritySystemConditions>(SecuritySystemConditions.PowerStatus,"Online")
             };
 
             var serviceProvider = new ServiceCollection()
@@ -74,21 +61,9 @@ namespace Rules.Framework.IntegrationTests.Scenarios.Scenario3
             var expectedMatchDate = new DateTime(2018, 06, 01);
             var expectedConditions = new[]
             {
-                new Condition<SecuritySystemConditions>
-                {
-                    Type = SecuritySystemConditions.TemperatureCelsius,
-                    Value = 100.0m
-                },
-                new Condition<SecuritySystemConditions>
-                {
-                    Type = SecuritySystemConditions.SmokeRate,
-                    Value = 55.0m
-                },
-                new Condition<SecuritySystemConditions>
-                {
-                    Type = SecuritySystemConditions.PowerStatus,
-                    Value = "Offline"
-                }
+                new Condition<SecuritySystemConditions>(SecuritySystemConditions.TemperatureCelsius,100.0m),
+                new Condition<SecuritySystemConditions>(SecuritySystemConditions.SmokeRate,55),
+                new Condition<SecuritySystemConditions>(SecuritySystemConditions.PowerStatus,"Offline")
             };
 
             var serviceProvider = new ServiceCollection()
@@ -125,21 +100,9 @@ namespace Rules.Framework.IntegrationTests.Scenarios.Scenario3
             var expectedMatchDate = new DateTime(2018, 06, 01);
             var expectedConditions = new[]
             {
-                new Condition<SecuritySystemConditions>
-                {
-                    Type = SecuritySystemConditions.TemperatureCelsius,
-                    Value = 100.0m
-                },
-                new Condition<SecuritySystemConditions>
-                {
-                    Type = SecuritySystemConditions.SmokeRate,
-                    Value = 55.0m
-                },
-                new Condition<SecuritySystemConditions>
-                {
-                    Type = SecuritySystemConditions.PowerStatus,
-                    Value = "Shutdown"
-                }
+                new Condition<SecuritySystemConditions>(SecuritySystemConditions.TemperatureCelsius,100.0m),
+                new Condition<SecuritySystemConditions>(SecuritySystemConditions.SmokeRate,55),
+                new Condition<SecuritySystemConditions>(SecuritySystemConditions.PowerStatus,"Shutdown")
             };
 
             var serviceProvider = new ServiceCollection()

--- a/tests/Rules.Framework.IntegrationTests/Scenarios/Scenario4/DiscountCampaignTests.cs
+++ b/tests/Rules.Framework.IntegrationTests/Scenarios/Scenario4/DiscountCampaignTests.cs
@@ -8,7 +8,6 @@ namespace Rules.Framework.IntegrationTests.Scenarios.Scenario4
     using Microsoft.Extensions.DependencyInjection;
     using Rules.Framework.Core;
     using Rules.Framework.IntegrationTests.Common.Scenarios.Scenario4;
-    using Rules.Framework.Providers.InMemory;
     using Xunit;
 
     public class DiscountCampaignTests
@@ -71,16 +70,8 @@ namespace Rules.Framework.IntegrationTests.Scenarios.Scenario4
             var matchDateTime = DateTime.Parse("2021-05-29T12:34:52Z");
             var conditions = new[]
             {
-                new Condition<DiscountConditions>
-                {
-                    Type = DiscountConditions.ProductBrand,
-                    Value = "ASUS"
-                },
-                new Condition<DiscountConditions>
-                {
-                    Type = DiscountConditions.ProductRecommendedRetailPrice,
-                    Value = 1249.90m
-                }
+                new Condition<DiscountConditions>(DiscountConditions.ProductBrand,"ASUS"),
+                new Condition<DiscountConditions>(DiscountConditions.ProductRecommendedRetailPrice,1249.90m)
             };
 
             var actual = await rulesEngine.MatchOneAsync(DiscountConfigurations.DiscountCampaigns, matchDateTime, conditions).ConfigureAwait(false);
@@ -140,21 +131,9 @@ namespace Rules.Framework.IntegrationTests.Scenarios.Scenario4
             var matchDateTime = DateTime.Parse("2021-05-29T12:34:52Z");
             var conditions = new[]
             {
-                new Condition<DiscountConditions>
-                {
-                    Type = DiscountConditions.ProductBrand,
-                    Value = "ASUS"
-                },
-                new Condition<DiscountConditions>
-                {
-                    Type = DiscountConditions.ProductTier,
-                    Value = 1
-                },
-                new Condition<DiscountConditions>
-                {
-                    Type = DiscountConditions.ProductRecommendedRetailPrice,
-                    Value = 1249.90m
-                }
+                new Condition<DiscountConditions>(DiscountConditions.ProductBrand, "ASUS"),
+                new Condition<DiscountConditions>(DiscountConditions.ProductTier, 1),
+                new Condition<DiscountConditions>(DiscountConditions.ProductRecommendedRetailPrice, 1249.90m)
             };
 
             var actual = await rulesEngine.MatchOneAsync(DiscountConfigurations.DiscountCampaigns, matchDateTime, conditions).ConfigureAwait(false);
@@ -213,11 +192,7 @@ namespace Rules.Framework.IntegrationTests.Scenarios.Scenario4
             var matchDateTime = DateTime.Parse("2021-05-29T12:34:52Z");
             var conditions = new[]
             {
-                new Condition<DiscountConditions>
-                {
-                    Type = DiscountConditions.CustomerEmail,
-                    Value = "user12345@somewhere.com"
-                }
+                new Condition<DiscountConditions>(DiscountConditions.CustomerEmail, "user12345@somewhere.com")
             };
 
             var actual = await rulesEngine.MatchOneAsync(DiscountConfigurations.DiscountCampaigns, matchDateTime, conditions).ConfigureAwait(false);
@@ -276,11 +251,7 @@ namespace Rules.Framework.IntegrationTests.Scenarios.Scenario4
             var matchDateTime = DateTime.Parse("2021-05-29T12:34:52Z");
             var conditions = new[]
             {
-                new Condition<DiscountConditions>
-                {
-                    Type = DiscountConditions.ProductColor,
-                    Value = ProductColor.Blue.ToString()
-                }
+                new Condition<DiscountConditions>(DiscountConditions.ProductColor, ProductColor.Blue.ToString())
             };
 
             var actual = await rulesEngine.MatchOneAsync(DiscountConfigurations.DiscountCampaigns, matchDateTime, conditions).ConfigureAwait(false);
@@ -394,11 +365,7 @@ namespace Rules.Framework.IntegrationTests.Scenarios.Scenario4
             var matchDateTime = DateTime.Parse("2021-05-29T12:34:52Z");
             var conditions = new[]
             {
-                new Condition<DiscountConditions>
-                {
-                    Type = DiscountConditions.ProductColor,
-                    Value = ProductColor.White.ToString()
-                }
+                new Condition<DiscountConditions>(DiscountConditions.ProductColor, ProductColor.White.ToString())
             };
 
             var actual = await rulesEngine.MatchOneAsync(DiscountConfigurations.DiscountCampaigns, matchDateTime, conditions).ConfigureAwait(false);

--- a/tests/Rules.Framework.IntegrationTests/Scenarios/Scenario8/TexasHoldEmPokerSingleCombinationsTests.cs
+++ b/tests/Rules.Framework.IntegrationTests/Scenarios/Scenario8/TexasHoldEmPokerSingleCombinationsTests.cs
@@ -5,7 +5,6 @@ namespace Rules.Framework.IntegrationTests.Scenarios.Scenario8
     using FluentAssertions;
     using Rules.Framework.BenchmarkTests.Tests.Benchmark3;
     using Rules.Framework.IntegrationTests.Common.Scenarios;
-    using Rules.Framework.Providers.InMemory;
     using Xunit;
 
     public class TexasHoldEmPokerSingleCombinationsTests

--- a/tests/Rules.Framework.IntegrationTests/Scenarios/Scenario8/TexasHoldEmPokerSingleCombinationsTests.cs
+++ b/tests/Rules.Framework.IntegrationTests/Scenarios/Scenario8/TexasHoldEmPokerSingleCombinationsTests.cs
@@ -5,6 +5,7 @@ namespace Rules.Framework.IntegrationTests.Scenarios.Scenario8
     using FluentAssertions;
     using Rules.Framework.BenchmarkTests.Tests.Benchmark3;
     using Rules.Framework.IntegrationTests.Common.Scenarios;
+    using Rules.Framework.Providers.InMemory;
     using Xunit;
 
     public class TexasHoldEmPokerSingleCombinationsTests

--- a/tests/Rules.Framework.Providers.InMemory.IntegrationTests/Scenarios/Scenario2/CarInsuranceAdvisorTests.cs
+++ b/tests/Rules.Framework.Providers.InMemory.IntegrationTests/Scenarios/Scenario2/CarInsuranceAdvisorTests.cs
@@ -34,16 +34,8 @@ namespace Rules.Framework.Providers.InMemory.IntegrationTests.Scenarios.Scenario
             var expectedMatchDate = new DateTime(2016, 06, 01, 20, 23, 23);
             var expectedConditions = new[]
             {
-                new Condition<ConditionTypes>
-                {
-                    Type = ConditionTypes.RepairCosts,
-                    Value = 0.0m
-                },
-                new Condition<ConditionTypes>
-                {
-                    Type = ConditionTypes.RepairCostsCommercialValueRate,
-                    Value = 0.0m
-                }
+                new Condition<ConditionTypes>(ConditionTypes.RepairCosts, 0.0m),
+                new Condition<ConditionTypes>(ConditionTypes.RepairCostsCommercialValueRate, 0.0m)
             };
 
             var serviceDescriptors = new ServiceCollection();
@@ -78,16 +70,8 @@ namespace Rules.Framework.Providers.InMemory.IntegrationTests.Scenarios.Scenario
             var expectedMatchDate = new DateTime(2018, 06, 01);
             var expectedConditions = new[]
             {
-                new Condition<ConditionTypes>
-                {
-                    Type = ConditionTypes.RepairCosts,
-                    Value = 800.00000m
-                },
-                new Condition<ConditionTypes>
-                {
-                    Type = ConditionTypes.RepairCostsCommercialValueRate,
-                    Value = 23.45602m
-                }
+                new Condition<ConditionTypes>(ConditionTypes.RepairCosts, 800.00000m),
+                new Condition<ConditionTypes>(ConditionTypes.RepairCostsCommercialValueRate, 23.45602m)
             };
 
             var serviceDescriptors = new ServiceCollection();
@@ -121,16 +105,8 @@ namespace Rules.Framework.Providers.InMemory.IntegrationTests.Scenarios.Scenario
             var expectedMatchDate = new DateTime(2018, 06, 01);
             var expectedConditions = new[]
             {
-                new Condition<ConditionTypes>
-                {
-                    Type = ConditionTypes.RepairCosts,
-                    Value = 800.00000m
-                },
-                new Condition<ConditionTypes>
-                {
-                    Type = ConditionTypes.RepairCostsCommercialValueRate,
-                    Value = 23.45602m
-                }
+                new Condition<ConditionTypes>(ConditionTypes.RepairCosts, 800.00000m),
+                new Condition<ConditionTypes>(ConditionTypes.RepairCostsCommercialValueRate, 23.45602m)
             };
 
             var serviceDescriptors = new ServiceCollection();

--- a/tests/Rules.Framework.Providers.InMemory.IntegrationTests/Scenarios/Scenario3/BuildingSecuritySystemControlTests.cs
+++ b/tests/Rules.Framework.Providers.InMemory.IntegrationTests/Scenarios/Scenario3/BuildingSecuritySystemControlTests.cs
@@ -39,21 +39,9 @@ namespace Rules.Framework.Providers.InMemory.IntegrationTests.Scenarios.Scenario
             DateTime expectedMatchDate = new DateTime(2018, 06, 01);
             Condition<SecuritySystemConditions>[] expectedConditions = new Condition<SecuritySystemConditions>[]
             {
-                new Condition<SecuritySystemConditions>
-                {
-                    Type = SecuritySystemConditions.TemperatureCelsius,
-                    Value = 100.0m
-                },
-                new Condition<SecuritySystemConditions>
-                {
-                    Type = SecuritySystemConditions.SmokeRate,
-                    Value = 55.0m
-                },
-                new Condition<SecuritySystemConditions>
-                {
-                    Type = SecuritySystemConditions.PowerStatus,
-                    Value = "Online"
-                }
+                new Condition<SecuritySystemConditions>(SecuritySystemConditions.TemperatureCelsius, 100.0m),
+                new Condition<SecuritySystemConditions>(SecuritySystemConditions.SmokeRate, 55.0m),
+                new Condition<SecuritySystemConditions>(SecuritySystemConditions.PowerStatus, "Online")
             };
 
             IServiceCollection serviceDescriptors = new ServiceCollection();
@@ -95,21 +83,9 @@ namespace Rules.Framework.Providers.InMemory.IntegrationTests.Scenarios.Scenario
             DateTime expectedMatchDate = new DateTime(2018, 06, 01);
             Condition<SecuritySystemConditions>[] expectedConditions = new Condition<SecuritySystemConditions>[]
             {
-                new Condition<SecuritySystemConditions>
-                {
-                    Type = SecuritySystemConditions.TemperatureCelsius,
-                    Value = 100.0m
-                },
-                new Condition<SecuritySystemConditions>
-                {
-                    Type = SecuritySystemConditions.SmokeRate,
-                    Value = 55.0m
-                },
-                new Condition<SecuritySystemConditions>
-                {
-                    Type = SecuritySystemConditions.PowerStatus,
-                    Value = "Offline"
-                }
+                new Condition<SecuritySystemConditions>(SecuritySystemConditions.TemperatureCelsius, 100.0m),
+                new Condition<SecuritySystemConditions>(SecuritySystemConditions.SmokeRate, 55.0m),
+                new Condition<SecuritySystemConditions>(SecuritySystemConditions.PowerStatus, "Offline")
             };
 
             IServiceCollection serviceDescriptors = new ServiceCollection();
@@ -150,21 +126,9 @@ namespace Rules.Framework.Providers.InMemory.IntegrationTests.Scenarios.Scenario
             DateTime expectedMatchDate = new DateTime(2018, 06, 01);
             Condition<SecuritySystemConditions>[] expectedConditions = new Condition<SecuritySystemConditions>[]
             {
-                new Condition<SecuritySystemConditions>
-                {
-                    Type = SecuritySystemConditions.TemperatureCelsius,
-                    Value = 100.0m
-                },
-                new Condition<SecuritySystemConditions>
-                {
-                    Type = SecuritySystemConditions.SmokeRate,
-                    Value = 55.0m
-                },
-                new Condition<SecuritySystemConditions>
-                {
-                    Type = SecuritySystemConditions.PowerStatus,
-                    Value = "Shutdown"
-                }
+                new Condition<SecuritySystemConditions>(SecuritySystemConditions.TemperatureCelsius, 100.0m),
+                new Condition<SecuritySystemConditions>(SecuritySystemConditions.SmokeRate, 55.0m),
+                new Condition<SecuritySystemConditions>(SecuritySystemConditions.PowerStatus, "Shutdown")
             };
 
             IServiceCollection serviceDescriptors = new ServiceCollection();

--- a/tests/Rules.Framework.Providers.MongoDb.IntegrationTests/Scenarios/Scenario2/CarInsuranceAdvisorTests.cs
+++ b/tests/Rules.Framework.Providers.MongoDb.IntegrationTests/Scenarios/Scenario2/CarInsuranceAdvisorTests.cs
@@ -73,16 +73,8 @@ namespace Rules.Framework.Providers.MongoDb.IntegrationTests.Scenarios.Scenario2
             var expectedMatchDate = new DateTime(2018, 06, 01);
             var expectedConditions = new[]
             {
-                new Condition<ConditionTypes>
-                {
-                    Type = ConditionTypes.RepairCosts,
-                    Value = 800.00000m
-                },
-                new Condition<ConditionTypes>
-                {
-                    Type = ConditionTypes.RepairCostsCommercialValueRate,
-                    Value = 23.45602m
-                }
+                new Condition<ConditionTypes>(ConditionTypes.RepairCosts, 800.00000m),
+                new Condition<ConditionTypes>(ConditionTypes.RepairCostsCommercialValueRate, 23.45602m)
             };
 
             var rulesEngine = RulesEngineBuilder.CreateRulesEngine()
@@ -112,16 +104,8 @@ namespace Rules.Framework.Providers.MongoDb.IntegrationTests.Scenarios.Scenario2
             var expectedMatchDate = new DateTime(2018, 06, 01);
             var expectedConditions = new[]
             {
-                new Condition<ConditionTypes>
-                {
-                    Type = ConditionTypes.RepairCosts,
-                    Value = 800.00000m
-                },
-                new Condition<ConditionTypes>
-                {
-                    Type = ConditionTypes.RepairCostsCommercialValueRate,
-                    Value = 23.45602m
-                }
+                new Condition<ConditionTypes>(ConditionTypes.RepairCosts, 800.00000m),
+                new Condition<ConditionTypes>(ConditionTypes.RepairCostsCommercialValueRate, 23.45602m)
             };
 
             var rulesEngine = RulesEngineBuilder.CreateRulesEngine()

--- a/tests/Rules.Framework.Providers.MongoDb.IntegrationTests/Scenarios/Scenario3/BuildingSecuritySystemControlTests.cs
+++ b/tests/Rules.Framework.Providers.MongoDb.IntegrationTests/Scenarios/Scenario3/BuildingSecuritySystemControlTests.cs
@@ -66,21 +66,9 @@ namespace Rules.Framework.Providers.MongoDb.IntegrationTests.Scenarios.Scenario3
             var expectedMatchDate = new DateTime(2018, 06, 01);
             var expectedConditions = new[]
             {
-                new Condition<SecuritySystemConditions>
-                {
-                    Type = SecuritySystemConditions.TemperatureCelsius,
-                    Value = 100.0m
-                },
-                new Condition<SecuritySystemConditions>
-                {
-                    Type = SecuritySystemConditions.SmokeRate,
-                    Value = 55.0m
-                },
-                new Condition<SecuritySystemConditions>
-                {
-                    Type = SecuritySystemConditions.PowerStatus,
-                    Value = "Online"
-                }
+                new Condition<SecuritySystemConditions>(SecuritySystemConditions.TemperatureCelsius, 100.0m),
+                new Condition<SecuritySystemConditions>(SecuritySystemConditions.SmokeRate, 55.0m),
+                new Condition<SecuritySystemConditions>(SecuritySystemConditions.PowerStatus, "Online")
             };
 
             var rulesEngine = RulesEngineBuilder.CreateRulesEngine()
@@ -112,21 +100,9 @@ namespace Rules.Framework.Providers.MongoDb.IntegrationTests.Scenarios.Scenario3
             var expectedMatchDate = new DateTime(2018, 06, 01);
             var expectedConditions = new[]
             {
-                new Condition<SecuritySystemConditions>
-                {
-                    Type = SecuritySystemConditions.TemperatureCelsius,
-                    Value = 100.0m
-                },
-                new Condition<SecuritySystemConditions>
-                {
-                    Type = SecuritySystemConditions.SmokeRate,
-                    Value = 55.0m
-                },
-                new Condition<SecuritySystemConditions>
-                {
-                    Type = SecuritySystemConditions.PowerStatus,
-                    Value = "Offline"
-                }
+                new Condition<SecuritySystemConditions>(SecuritySystemConditions.TemperatureCelsius, 100.0m),
+                new Condition<SecuritySystemConditions>(SecuritySystemConditions.SmokeRate, 55.0m),
+                new Condition<SecuritySystemConditions>(SecuritySystemConditions.PowerStatus, "Offline")
             };
 
             var rulesEngine = RulesEngineBuilder.CreateRulesEngine()
@@ -157,21 +133,9 @@ namespace Rules.Framework.Providers.MongoDb.IntegrationTests.Scenarios.Scenario3
             var expectedMatchDate = new DateTime(2018, 06, 01);
             var expectedConditions = new[]
             {
-                new Condition<SecuritySystemConditions>
-                {
-                    Type = SecuritySystemConditions.TemperatureCelsius,
-                    Value = 100.0m
-                },
-                new Condition<SecuritySystemConditions>
-                {
-                    Type = SecuritySystemConditions.SmokeRate,
-                    Value = 55.0m
-                },
-                new Condition<SecuritySystemConditions>
-                {
-                    Type = SecuritySystemConditions.PowerStatus,
-                    Value = "Shutdown"
-                }
+                new Condition<SecuritySystemConditions>(SecuritySystemConditions.TemperatureCelsius, 100.0m),
+                new Condition<SecuritySystemConditions>(SecuritySystemConditions.SmokeRate, 55.0m),
+                new Condition<SecuritySystemConditions>(SecuritySystemConditions.PowerStatus, "Shutdown")
             };
 
             var rulesEngine = RulesEngineBuilder.CreateRulesEngine()

--- a/tests/Rules.Framework.Providers.MongoDb.IntegrationTests/Scenarios/Scenaro5/BestServerTests.cs
+++ b/tests/Rules.Framework.Providers.MongoDb.IntegrationTests/Scenarios/Scenaro5/BestServerTests.cs
@@ -19,26 +19,10 @@ namespace Rules.Framework.Providers.MongoDb.IntegrationTests.Scenarios.Scenario5
             {
                 new[]
                 {
-                    new Condition<BestServerConditions>
-                    {
-                        Type = BestServerConditions.Price,
-                        Value = 100
-                    },
-                    new Condition<BestServerConditions>
-                    {
-                        Type = BestServerConditions.Memory,
-                        Value = 12
-                    },
-                    new Condition<BestServerConditions>
-                    {
-                        Type = BestServerConditions.StoragePartionable,
-                        Value = true
-                    },
-                    new Condition<BestServerConditions>
-                    {
-                        Type = BestServerConditions.Brand,
-                        Value = "AMD"
-                    }
+                    new Condition<BestServerConditions>(BestServerConditions.Price, 100),
+                    new Condition<BestServerConditions>(BestServerConditions.Memory, 12),
+                    new Condition<BestServerConditions>(BestServerConditions.StoragePartionable, true),
+                    new Condition<BestServerConditions>(BestServerConditions.Brand, "AMD")
                 },
                 "Best Server Top5"
             },
@@ -46,26 +30,10 @@ namespace Rules.Framework.Providers.MongoDb.IntegrationTests.Scenarios.Scenario5
             {
                 new[]
                 {
-                    new Condition<BestServerConditions>
-                    {
-                        Type = BestServerConditions.Price,
-                        Value = 110
-                    },
-                    new Condition<BestServerConditions>
-                    {
-                        Type = BestServerConditions.Memory,
-                        Value = 12
-                    },
-                    new Condition<BestServerConditions>
-                    {
-                        Type = BestServerConditions.StoragePartionable,
-                        Value = true
-                    },
-                    new Condition<BestServerConditions>
-                    {
-                        Type = BestServerConditions.Brand,
-                        Value = "AMD"
-                    }
+                    new Condition<BestServerConditions>(BestServerConditions.Price, 110),
+                    new Condition<BestServerConditions>(BestServerConditions.Memory, 12),
+                    new Condition<BestServerConditions>(BestServerConditions.StoragePartionable, true),
+                    new Condition<BestServerConditions>(BestServerConditions.Brand, "AMD")
                 },
                 "Best Server Default"
             }

--- a/tests/Rules.Framework.Providers.MongoDb.Tests/RuleFactoryTests.cs
+++ b/tests/Rules.Framework.Providers.MongoDb.Tests/RuleFactoryTests.cs
@@ -1,7 +1,6 @@
 namespace Rules.Framework.Providers.MongoDb.Tests
 {
     using System;
-    using System.Collections.Generic;
     using System.Dynamic;
     using System.Linq;
     using FluentAssertions;
@@ -22,12 +21,12 @@ namespace Rules.Framework.Providers.MongoDb.Tests
             // Arrange
             Rule<ContentType, ConditionType> rule = null;
 
-            IContentSerializationProvider<ContentType> contentSerializationProvider = Mock.Of<IContentSerializationProvider<ContentType>>();
+            var contentSerializationProvider = Mock.Of<IContentSerializationProvider<ContentType>>();
 
-            RuleFactory<ContentType, ConditionType> ruleFactory = new RuleFactory<ContentType, ConditionType>(contentSerializationProvider);
+            var ruleFactory = new RuleFactory<ContentType, ConditionType>(contentSerializationProvider);
 
             // Act
-            ArgumentNullException argumentNullException = Assert.Throws<ArgumentNullException>(() => ruleFactory.CreateRule(rule));
+            var argumentNullException = Assert.Throws<ArgumentNullException>(() => ruleFactory.CreateRule(rule));
 
             // Assert
             argumentNullException.Should().NotBeNull();
@@ -40,12 +39,12 @@ namespace Rules.Framework.Providers.MongoDb.Tests
             // Arrange
             RuleDataModel ruleDataModel = null;
 
-            IContentSerializationProvider<ContentType> contentSerializationProvider = Mock.Of<IContentSerializationProvider<ContentType>>();
+            var contentSerializationProvider = Mock.Of<IContentSerializationProvider<ContentType>>();
 
-            RuleFactory<ContentType, ConditionType> ruleFactory = new RuleFactory<ContentType, ConditionType>(contentSerializationProvider);
+            var ruleFactory = new RuleFactory<ContentType, ConditionType>(contentSerializationProvider);
 
             // Act
-            ArgumentNullException argumentNullException = Assert.Throws<ArgumentNullException>(() => ruleFactory.CreateRule(ruleDataModel));
+            var argumentNullException = Assert.Throws<ArgumentNullException>(() => ruleFactory.CreateRule(ruleDataModel));
 
             // Assert
             argumentNullException.Should().NotBeNull();
@@ -61,7 +60,7 @@ namespace Rules.Framework.Providers.MongoDb.Tests
             content.Prop2 = "Sample string";
             content.Prop3 = 500.34m;
 
-            ValueConditionNodeDataModel integerConditionNodeDataModel = new ValueConditionNodeDataModel
+            var integerConditionNodeDataModel = new ValueConditionNodeDataModel
             {
                 ConditionType = "SampleIntegerCondition",
                 DataType = DataTypes.Integer,
@@ -70,7 +69,7 @@ namespace Rules.Framework.Providers.MongoDb.Tests
                 Operator = Operators.GreaterThan
             };
 
-            ValueConditionNodeDataModel stringConditionNodeDataModel = new ValueConditionNodeDataModel
+            var stringConditionNodeDataModel = new ValueConditionNodeDataModel
             {
                 ConditionType = "SampleStringCondition",
                 DataType = DataTypes.String,
@@ -79,7 +78,7 @@ namespace Rules.Framework.Providers.MongoDb.Tests
                 Operator = Operators.Equal
             };
 
-            ValueConditionNodeDataModel decimalConditionNodeDataModel = new ValueConditionNodeDataModel
+            var decimalConditionNodeDataModel = new ValueConditionNodeDataModel
             {
                 ConditionType = "SampleDecimalCondition",
                 DataType = DataTypes.Decimal,
@@ -88,7 +87,7 @@ namespace Rules.Framework.Providers.MongoDb.Tests
                 Operator = Operators.LesserThanOrEqual
             };
 
-            ValueConditionNodeDataModel booleanConditionNodeDataModel = new ValueConditionNodeDataModel
+            var booleanConditionNodeDataModel = new ValueConditionNodeDataModel
             {
                 ConditionType = "SampleBooleanCondition",
                 DataType = DataTypes.Boolean,
@@ -97,7 +96,7 @@ namespace Rules.Framework.Providers.MongoDb.Tests
                 Operator = Operators.NotEqual
             };
 
-            RuleDataModel ruleDataModel = new RuleDataModel
+            var ruleDataModel = new RuleDataModel
             {
                 Content = content,
                 ContentType = "ContentTypeSample",
@@ -118,30 +117,30 @@ namespace Rules.Framework.Providers.MongoDb.Tests
                 }
             };
 
-            IContentSerializationProvider<ContentType> contentSerializationProvider = Mock.Of<IContentSerializationProvider<ContentType>>();
+            var contentSerializationProvider = Mock.Of<IContentSerializationProvider<ContentType>>();
 
-            RuleFactory<ContentType, ConditionType> ruleFactory = new RuleFactory<ContentType, ConditionType>(contentSerializationProvider);
+            var ruleFactory = new RuleFactory<ContentType, ConditionType>(contentSerializationProvider);
 
             // Act
-            Rule<ContentType, ConditionType> rule = ruleFactory.CreateRule(ruleDataModel);
+            var rule = ruleFactory.CreateRule(ruleDataModel);
 
             // Assert
             rule.Should().NotBeNull();
-            rule.ContentContainer.Should().NotBeNull()
-                .And.BeOfType<SerializedContentContainer<ContentType>>();
+            rule.ContentContainer.Should().NotBeNull().And.BeOfType<SerializedContentContainer<ContentType>>();
             rule.DateBegin.Should().Be(ruleDataModel.DateBegin);
             rule.DateEnd.Should().BeNull();
             rule.Name.Should().Be(ruleDataModel.Name);
             rule.Priority.Should().Be(ruleDataModel.Priority);
             rule.RootCondition.Should().BeOfType<ComposedConditionNode<ConditionType>>();
 
-            ComposedConditionNode<ConditionType> composedConditionNode = rule.RootCondition.As<ComposedConditionNode<ConditionType>>();
+            var composedConditionNode = rule.RootCondition.As<ComposedConditionNode<ConditionType>>();
             composedConditionNode.LogicalOperator.Should().Be(LogicalOperators.And);
             composedConditionNode.ChildConditionNodes.Should().HaveCount(4);
 
-            IEnumerable<ValueConditionNode<ConditionType>> valueConditionNodes = composedConditionNode.ChildConditionNodes.OfType<ValueConditionNode<ConditionType>>();
+            var valueConditionNodes = composedConditionNode.ChildConditionNodes.OfType<ValueConditionNode<ConditionType>>();
             valueConditionNodes.Should().HaveCount(4);
-            ValueConditionNode<ConditionType> integerConditionNode = valueConditionNodes.First(x => x.DataType == DataTypes.Integer);
+
+            var integerConditionNode = valueConditionNodes.First(x => x.DataType == DataTypes.Integer);
             integerConditionNode.Should().NotBeNull();
             integerConditionNode.ConditionType.Should().Match(x => x == Enum.Parse<ConditionType>(integerConditionNodeDataModel.ConditionType));
             integerConditionNode.DataType.Should().Be(integerConditionNodeDataModel.DataType);
@@ -149,7 +148,7 @@ namespace Rules.Framework.Providers.MongoDb.Tests
             integerConditionNode.Operand.Should().Match(x => object.Equals(x, integerConditionNodeDataModel.Operand));
             integerConditionNode.Operator.Should().Be(integerConditionNodeDataModel.Operator);
 
-            ValueConditionNode<ConditionType> stringConditionNode = valueConditionNodes.First(x => x.DataType == DataTypes.String);
+            var stringConditionNode = valueConditionNodes.First(x => x.DataType == DataTypes.String);
             stringConditionNode.Should().NotBeNull();
             stringConditionNode.ConditionType.Should().Match(x => x == Enum.Parse<ConditionType>(stringConditionNodeDataModel.ConditionType));
             stringConditionNode.DataType.Should().Be(stringConditionNodeDataModel.DataType);
@@ -157,7 +156,7 @@ namespace Rules.Framework.Providers.MongoDb.Tests
             stringConditionNode.Operand.Should().Match(x => object.Equals(x, stringConditionNodeDataModel.Operand));
             stringConditionNode.Operator.Should().Be(stringConditionNodeDataModel.Operator);
 
-            ValueConditionNode<ConditionType> decimalConditionNode = valueConditionNodes.First(x => x.DataType == DataTypes.Decimal);
+            var decimalConditionNode = valueConditionNodes.First(x => x.DataType == DataTypes.Decimal);
             decimalConditionNode.Should().NotBeNull();
             decimalConditionNode.ConditionType.Should().Match(x => x == Enum.Parse<ConditionType>(decimalConditionNodeDataModel.ConditionType));
             decimalConditionNode.DataType.Should().Be(decimalConditionNodeDataModel.DataType);
@@ -165,7 +164,7 @@ namespace Rules.Framework.Providers.MongoDb.Tests
             decimalConditionNode.Operand.Should().Match(x => object.Equals(x, decimalConditionNodeDataModel.Operand));
             decimalConditionNode.Operator.Should().Be(decimalConditionNodeDataModel.Operator);
 
-            ValueConditionNode<ConditionType> booleanConditionNode = valueConditionNodes.First(x => x.DataType == DataTypes.Boolean);
+            var booleanConditionNode = valueConditionNodes.First(x => x.DataType == DataTypes.Boolean);
             booleanConditionNode.Should().NotBeNull();
             booleanConditionNode.ConditionType.Should().Match(x => x == Enum.Parse<ConditionType>(booleanConditionNodeDataModel.ConditionType));
             booleanConditionNode.DataType.Should().Be(booleanConditionNodeDataModel.DataType);
@@ -183,12 +182,12 @@ namespace Rules.Framework.Providers.MongoDb.Tests
             content.Prop2 = "Sample string";
             content.Prop3 = 500.34m;
 
-            IContentSerializer contentSerializer = Mock.Of<IContentSerializer>();
+            var contentSerializer = Mock.Of<IContentSerializer>();
             Mock.Get(contentSerializer)
                 .Setup(x => x.Deserialize(It.IsAny<object>(), It.IsAny<Type>()))
                 .Returns((object)content);
 
-            IContentSerializationProvider<ContentType> contentSerializationProvider = Mock.Of<IContentSerializationProvider<ContentType>>();
+            var contentSerializationProvider = Mock.Of<IContentSerializationProvider<ContentType>>();
             Mock.Get(contentSerializationProvider)
                 .Setup(x => x.GetContentSerializer(ContentType.ContentTypeSample))
                 .Returns(contentSerializer);
@@ -202,7 +201,7 @@ namespace Rules.Framework.Providers.MongoDb.Tests
             var stringConditionNode = ConditionNodeFactory
                 .CreateValueNode(ConditionType.SampleStringCondition, Operators.Equal, "TEST") as ValueConditionNode<ConditionType>;
 
-            Rule<ContentType, ConditionType> rule1 = RuleBuilder.NewRule<ContentType, ConditionType>()
+            var rule = RuleBuilder.NewRule<ContentType, ConditionType>()
                 .WithName("My rule used for testing purposes")
                 .WithDateBegin(new DateTime(2020, 1, 1))
                 .WithContent(ContentType.ContentTypeSample, (object)content)
@@ -215,29 +214,29 @@ namespace Rules.Framework.Providers.MongoDb.Tests
                     ))
                 .Build().Rule;
 
-            RuleFactory<ContentType, ConditionType> ruleFactory = new RuleFactory<ContentType, ConditionType>(contentSerializationProvider);
+            var ruleFactory = new RuleFactory<ContentType, ConditionType>(contentSerializationProvider);
 
             // Act
-            RuleDataModel rule = ruleFactory.CreateRule(rule1);
+            var ruleDataModel = ruleFactory.CreateRule(rule);
 
             // Assert
-            rule.Should().NotBeNull();
-            object content1 = rule.Content;
-            content1.Should().NotBeNull()
-                .And.BeSameAs(content);
-            rule.DateBegin.Should().Be(rule.DateBegin);
-            rule.DateEnd.Should().BeNull();
-            rule.Name.Should().Be(rule.Name);
-            rule.Priority.Should().Be(rule.Priority);
-            rule.RootCondition.Should().BeOfType<ComposedConditionNodeDataModel>();
+            ruleDataModel.Should().NotBeNull();
+            object ruleDataModelContent = ruleDataModel.Content;
+            ruleDataModelContent.Should().NotBeNull().And.BeSameAs(content);
+            ruleDataModel.DateBegin.Should().Be(ruleDataModel.DateBegin);
+            ruleDataModel.DateEnd.Should().BeNull();
+            ruleDataModel.Name.Should().Be(ruleDataModel.Name);
+            ruleDataModel.Priority.Should().Be(ruleDataModel.Priority);
+            ruleDataModel.RootCondition.Should().BeOfType<ComposedConditionNodeDataModel>();
 
-            ComposedConditionNodeDataModel composedConditionNodeDataModel = rule.RootCondition.As<ComposedConditionNodeDataModel>();
+            var composedConditionNodeDataModel = ruleDataModel.RootCondition.As<ComposedConditionNodeDataModel>();
             composedConditionNodeDataModel.LogicalOperator.Should().Be(LogicalOperators.And);
             composedConditionNodeDataModel.ChildConditionNodes.Should().HaveCount(4);
 
-            IEnumerable<ValueConditionNodeDataModel> valueConditionNodeDataModels = composedConditionNodeDataModel.ChildConditionNodes.OfType<ValueConditionNodeDataModel>();
+            var valueConditionNodeDataModels = composedConditionNodeDataModel.ChildConditionNodes.OfType<ValueConditionNodeDataModel>();
             valueConditionNodeDataModels.Should().HaveCount(4);
-            ValueConditionNodeDataModel integerConditionNodeDataModel = valueConditionNodeDataModels.First(v => v.DataType == DataTypes.Integer);
+
+            var integerConditionNodeDataModel = valueConditionNodeDataModels.First(v => v.DataType == DataTypes.Integer);
             integerConditionNodeDataModel.Should().NotBeNull();
             integerConditionNodeDataModel.ConditionType.Should().Match<string>(x => integerConditionNode.ConditionType == Enum.Parse<ConditionType>(x));
             integerConditionNodeDataModel.DataType.Should().Be(integerConditionNode.DataType);
@@ -245,7 +244,7 @@ namespace Rules.Framework.Providers.MongoDb.Tests
             integerConditionNodeDataModel.Operand.Should().Match(x => object.Equals(x, integerConditionNode.Operand));
             integerConditionNodeDataModel.Operator.Should().Be(integerConditionNode.Operator);
 
-            ValueConditionNodeDataModel stringConditionNodeDataModel = valueConditionNodeDataModels.First(v => v.DataType == DataTypes.String);
+            var stringConditionNodeDataModel = valueConditionNodeDataModels.First(v => v.DataType == DataTypes.String);
             stringConditionNodeDataModel.Should().NotBeNull();
             stringConditionNodeDataModel.ConditionType.Should().Match<string>(x => stringConditionNode.ConditionType == Enum.Parse<ConditionType>(x));
             stringConditionNodeDataModel.DataType.Should().Be(stringConditionNode.DataType);
@@ -253,7 +252,7 @@ namespace Rules.Framework.Providers.MongoDb.Tests
             stringConditionNodeDataModel.Operand.Should().Match(x => object.Equals(x, stringConditionNode.Operand));
             stringConditionNodeDataModel.Operator.Should().Be(stringConditionNode.Operator);
 
-            ValueConditionNodeDataModel decimalConditionNodeDataModel = valueConditionNodeDataModels.First(v => v.DataType == DataTypes.Decimal);
+            var decimalConditionNodeDataModel = valueConditionNodeDataModels.First(v => v.DataType == DataTypes.Decimal);
             decimalConditionNodeDataModel.Should().NotBeNull();
             decimalConditionNodeDataModel.ConditionType.Should().Match<string>(x => decimalConditionNode.ConditionType == Enum.Parse<ConditionType>(x));
             decimalConditionNodeDataModel.DataType.Should().Be(decimalConditionNode.DataType);
@@ -261,7 +260,7 @@ namespace Rules.Framework.Providers.MongoDb.Tests
             decimalConditionNodeDataModel.Operand.Should().Match(x => object.Equals(x, decimalConditionNode.Operand));
             decimalConditionNodeDataModel.Operator.Should().Be(decimalConditionNode.Operator);
 
-            ValueConditionNodeDataModel booleanConditionNodeDataModel = valueConditionNodeDataModels.First(v => v.DataType == DataTypes.Boolean);
+            var booleanConditionNodeDataModel = valueConditionNodeDataModels.First(v => v.DataType == DataTypes.Boolean);
             booleanConditionNodeDataModel.Should().NotBeNull();
             booleanConditionNodeDataModel.ConditionType.Should().Match<string>(x => booleanConditionNode.ConditionType == Enum.Parse<ConditionType>(x));
             booleanConditionNodeDataModel.DataType.Should().Be(booleanConditionNode.DataType);

--- a/tests/Rules.Framework.Providers.MongoDb.Tests/RuleFactoryTests.cs
+++ b/tests/Rules.Framework.Providers.MongoDb.Tests/RuleFactoryTests.cs
@@ -208,10 +208,10 @@ namespace Rules.Framework.Providers.MongoDb.Tests
                 .WithContent(ContentType.ContentTypeSample, (object)content)
                 .WithCondition(c => c
                     .And(a => a
-                        .Value(booleanConditionNode)
-                        .Value(decimalConditionNode)
-                        .Value(integerConditionNode)
-                        .Value(stringConditionNode)
+                        .Condition(booleanConditionNode)
+                        .Condition(decimalConditionNode)
+                        .Condition(integerConditionNode)
+                        .Condition(stringConditionNode)
                     ))
                 .Build().Rule;
 

--- a/tests/Rules.Framework.Tests/ConditionTests.cs
+++ b/tests/Rules.Framework.Tests/ConditionTests.cs
@@ -7,7 +7,7 @@ namespace Rules.Framework.Tests
     public class ConditionTests
     {
         [Fact]
-        public void Type_HavingSettedType_ReturnsSettedValue()
+        public void Condition_Ctor_Success()
         {
             // Arrange
             var expectedType = ConditionType.IsoCountryCode;

--- a/tests/Rules.Framework.Tests/ConditionTests.cs
+++ b/tests/Rules.Framework.Tests/ConditionTests.cs
@@ -10,36 +10,15 @@ namespace Rules.Framework.Tests
         public void Type_HavingSettedType_ReturnsSettedValue()
         {
             // Arrange
-            ConditionType expected = ConditionType.IsoCountryCode;
-
-            Condition<ConditionType> sut = new Condition<ConditionType>
-            {
-                Type = expected
-            };
+            var expectedType = ConditionType.IsoCountryCode;
+            var expectedValue = "abc";
 
             // Act
-            ConditionType actual = sut.Type;
+            var sut = new Condition<ConditionType>(expectedType, expectedValue);
 
             // Assert
-            actual.Should().Be(expected);
-        }
-
-        [Fact]
-        public void Value_HavingSettedValue_ReturnsSettedValue()
-        {
-            // Arrange
-            object expected = "abc";
-
-            Condition<ConditionType> sut = new Condition<ConditionType>
-            {
-                Value = expected
-            };
-
-            // Act
-            object actual = sut.Value;
-
-            // Assert
-            actual.Should().Be(expected);
+            sut.Type.Should().Be(expectedType);
+            sut.Value.Should().Be(expectedValue);
         }
     }
 }

--- a/tests/Rules.Framework.Tests/Extensions/GenericRuleExtensionsTests.cs
+++ b/tests/Rules.Framework.Tests/Extensions/GenericRuleExtensionsTests.cs
@@ -57,33 +57,20 @@ namespace Rules.Framework.Tests.Extensions
                 LogicalOperator = LogicalOperators.And
             };
 
-            var composedCondition = new ConditionNodeBuilder<ConditionType>()
-                .AsComposed()
-                      .WithLogicalOperator(LogicalOperators.And)
-                           .AddCondition(z => z
-                               .AsValued(ConditionType.IsVip).OfDataType<bool>()
-                               .WithComparisonOperator(Operators.Equal)
-                               .SetOperand(true)
-                               .Build()
-                           )
-                           .AddCondition(sub => sub.AsComposed()
-                                .WithLogicalOperator(LogicalOperators.Or)
-                                    .AddCondition(tri => tri
-                                        .AsValued(ConditionType.IsoCurrency).OfDataType<string>()
-                                        .WithComparisonOperator(Operators.Equal)
-                                        .SetOperand("EUR").Build())
-                                    .AddCondition(tri => tri
-                                        .AsValued(ConditionType.IsoCurrency).OfDataType<string>()
-                                        .WithComparisonOperator(Operators.Equal)
-                                        .SetOperand("USD").Build())
-                                .Build())
-                      .Build();
+            var rootComposedCondition = new RootConditionNodeBuilder<ConditionType>()
+                .And(a => a
+                    .Value(ConditionType.IsVip, Operators.Equal, true)
+                    .Or(o => o
+                        .Value(ConditionType.IsoCurrency, Operators.Equal, "EUR")
+                        .Value(ConditionType.IsoCurrency, Operators.Equal, "USD")
+                    )
+                );
 
             var ruleBuilderResult = RuleBuilder.NewRule<ContentType, ConditionType>()
                 .WithName("Dummy Rule")
                 .WithDateBegin(DateTime.Parse("2018-01-01"))
                 .WithContent(ContentType.Type1, expectedRuleContent)
-                .WithCondition(composedCondition)
+                .WithCondition(rootComposedCondition)
                 .Build();
 
             var rule = ruleBuilderResult.Rule;

--- a/tests/Rules.Framework.Tests/Extensions/GenericSearchArgsExtensionsTests.cs
+++ b/tests/Rules.Framework.Tests/Extensions/GenericSearchArgsExtensionsTests.cs
@@ -24,16 +24,8 @@ namespace Rules.Framework.Tests.Extensions
             {
                 Conditions = new List<Condition<ConditionType>>
                 {
-                    new Condition<ConditionType>
-                    {
-                        Type = ConditionType.PluviosityRate,
-                        Value = pluviosityRate
-                    },
-                    new Condition<ConditionType>
-                    {
-                        Type = ConditionType.IsoCountryCode,
-                        Value = countryCode
-                    }
+                    new Condition<ConditionType>(ConditionType.PluviosityRate, pluviosityRate),
+                    new Condition<ConditionType>(ConditionType.IsoCountryCode, countryCode)
                 },
                 ExcludeRulesWithoutSearchConditions = true
             };
@@ -46,16 +38,8 @@ namespace Rules.Framework.Tests.Extensions
             {
                 Conditions = new List<Condition<GenericConditionType>>
                 {
-                    new Condition<GenericConditionType>
-                    {
-                        Type = new GenericConditionType { Identifier = "PluviosityRate" },
-                        Value = pluviosityRate
-                    },
-                    new Condition<GenericConditionType>
-                    {
-                        Type = new GenericConditionType { Identifier = "IsoCountryCode" },
-                        Value = countryCode
-                    }
+                    new Condition<GenericConditionType>(new GenericConditionType { Identifier = "PluviosityRate" }, pluviosityRate),
+                    new Condition<GenericConditionType>(new GenericConditionType { Identifier = "IsoCountryCode" }, countryCode)
                 },
                 ExcludeRulesWithoutSearchConditions = true
             };

--- a/tests/Rules.Framework.Tests/Providers/InMemory/RuleFactoryTests.cs
+++ b/tests/Rules.Framework.Tests/Providers/InMemory/RuleFactoryTests.cs
@@ -252,10 +252,10 @@ namespace Rules.Framework.Tests.Providers.InMemory
                 .WithContent(ContentType.ContentTypeSample, (object)content)
                 .WithCondition(c => c
                     .And(a => a
-                        .Value(booleanConditionNode)
-                        .Value(decimalConditionNode)
-                        .Value(integerConditionNode)
-                        .Value(stringConditionNode)
+                        .Condition(booleanConditionNode)
+                        .Condition(decimalConditionNode)
+                        .Condition(integerConditionNode)
+                        .Condition(stringConditionNode)
                     ))
                 .Build().Rule;
 

--- a/tests/Rules.Framework.Tests/RulesEngineTests.cs
+++ b/tests/Rules.Framework.Tests/RulesEngineTests.cs
@@ -233,16 +233,8 @@ namespace Rules.Framework.Tests
             var contentType = ContentType.Type1;
             var conditions = new[]
             {
-                new Condition<ConditionType>
-                {
-                    Type = ConditionType.IsoCountryCode,
-                    Value = "USA"
-                },
-                new Condition<ConditionType>
-                {
-                    Type = ConditionType.IsoCurrency,
-                    Value = "USD"
-                }
+                new Condition<ConditionType>(ConditionType.IsoCountryCode, "USA"),
+                new Condition<ConditionType>(ConditionType.IsoCurrency, "USD")
             };
 
             var expected1 = new Rule<ContentType, ConditionType>
@@ -321,16 +313,8 @@ namespace Rules.Framework.Tests
             var contentType = ContentType.Type1;
             var conditions = new[]
             {
-                new Condition<ConditionType>
-                {
-                    Type = ConditionType.IsoCountryCode,
-                    Value = "USA"
-                },
-                new Condition<ConditionType>
-                {
-                    Type = ConditionType.IsoCurrency,
-                    Value = "USD"
-                }
+                new Condition<ConditionType>(ConditionType.IsoCountryCode, "USA"),
+                new Condition<ConditionType>(ConditionType.IsoCurrency, "USD")
             };
 
             var other = new Rule<ContentType, ConditionType>
@@ -395,16 +379,8 @@ namespace Rules.Framework.Tests
             var contentType = ContentType.Type1;
             var conditions = new[]
             {
-                new Condition<ConditionType>
-                {
-                    Type = ConditionType.IsoCountryCode,
-                    Value = "USA"
-                },
-                new Condition<ConditionType>
-                {
-                    Type = ConditionType.IsoCurrency,
-                    Value = "USD"
-                }
+                new Condition<ConditionType>(ConditionType.IsoCountryCode, "USA"),
+                new Condition<ConditionType>(ConditionType.IsoCurrency, "USD")
             };
 
             var expected = new Rule<ContentType, ConditionType>
@@ -467,16 +443,8 @@ namespace Rules.Framework.Tests
             var contentType = ContentType.Type1;
             var conditions = new[]
             {
-                new Condition<ConditionType>
-                {
-                    Type = ConditionType.IsoCountryCode,
-                    Value = "BRZ"
-                },
-                new Condition<ConditionType>
-                {
-                    Type = ConditionType.IsoCurrency,
-                    Value = "USD"
-                }
+                new Condition<ConditionType>(ConditionType.IsoCountryCode, "USA"),
+                new Condition<ConditionType>(ConditionType.IsoCurrency, "USD")
             };
 
             var rules = new[]

--- a/tests/Rules.Framework.Tests/Validation/SearchArgsValidatorTests.cs
+++ b/tests/Rules.Framework.Tests/Validation/SearchArgsValidatorTests.cs
@@ -18,11 +18,7 @@ namespace Rules.Framework.Tests.Validation
             {
                 Conditions = new[]
                 {
-                    new Condition<ConditionType>
-                    {
-                        Type = 0,
-                        Value = 1
-                    }
+                    new Condition<ConditionType>(0, 1)
                 }
             };
 
@@ -45,15 +41,7 @@ namespace Rules.Framework.Tests.Validation
             {
                 Conditions = new[]
                 {
-                    new Condition<ConditionTypeClass>
-                    {
-                        Type = new ConditionTypeClass
-                        {
-                            Id = 1,
-                            Name = "Sample Condition Type"
-                        },
-                        Value = 1
-                    }
+                    new Condition<ConditionTypeClass>(new ConditionTypeClass{Id = 1, Name = "Sample Condition Type" }, 1)
                 }
             };
 
@@ -75,11 +63,7 @@ namespace Rules.Framework.Tests.Validation
             {
                 Conditions = new[]
                 {
-                    new Condition<ConditionTypeClass>
-                    {
-                        Type = null,
-                        Value = 1
-                    }
+                    new Condition<ConditionTypeClass>(null, 1)
                 }
             };
 
@@ -102,11 +86,7 @@ namespace Rules.Framework.Tests.Validation
             {
                 Conditions = new[]
                 {
-                    new Condition<ConditionType>
-                    {
-                        Type = ConditionType.IsoCountryCode,
-                        Value = "PT"
-                    }
+                    new Condition<ConditionType>(ConditionType.IsoCountryCode,"PT")
                 }
             };
 


### PR DESCRIPTION
## Description

* Modify calls to use the new Condition ctor
* Turn Condition parameterless obsolete
* Renamed method in condition builders that accept a condition to Condition()

## Change checklist

- [ ] Code follows the [code rules guidelines](../CONTRIBUTING.md#code-rules) of this project
- [ ] Commit messages follow the [commit rules](../CONTRIBUTING.md#commit-rules) of this project
- [ ] I have self-reviewed my changes before submitting this pull request
- [ ] I have covered new/changed code with new tests and/or adjusted existent ones
- [ ] I have made changes necessary to update the documentation accordingly

Please also check the [_I want to contribute_](../CONTRIBUTING.md#i-want-to-contribute) guidelines and make sure you have done accordingly.

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)