### PR TITLE
Web UI added cut over dates

### DIFF
--- a/samples/Rules.Framework.WebUI.Sample/Enums/ContentTypes.cs
+++ b/samples/Rules.Framework.WebUI.Sample/Enums/ContentTypes.cs
@@ -2,22 +2,20 @@ namespace Rules.Framework.WebUI.Sample.Enums
 {
     public enum ContentTypes
     {
-        None = 0,
+        TestNumber = 0,
 
-        TestNumber = 1,
+        TestString = 1,
 
-        TestString = 2,
+        TestBoolean = 2,
 
-        TestBoolean = 3,
+        TestDecimal = 3,
 
-        TestDecimal = 4,
+        TestShort = 4,
 
-        TestShort = 5,
+        TestDateTime = 5,
 
-        TestDateTime = 6,
+        TestLong = 6,
 
-        TestLong = 7,
-
-        TestBlob = 8
+        TestBlob = 7
     }
 }

--- a/src/Rules.Framework.WebUI/Dto/FilterDto.cs
+++ b/src/Rules.Framework.WebUI/Dto/FilterDto.cs
@@ -2,7 +2,7 @@ namespace Rules.Framework.WebUI.Dto
 {
     using System;
 
-    internal class RulesFilterDto
+    internal sealed class RulesFilterDto
     {
         public string Content { get; set; }
         public string ContentType { get; set; }

--- a/src/Rules.Framework.WebUI/Dto/FilterDto.cs
+++ b/src/Rules.Framework.WebUI/Dto/FilterDto.cs
@@ -1,0 +1,14 @@
+namespace Rules.Framework.WebUI.Dto
+{
+    using System;
+
+    internal class RulesFilterDto
+    {
+        public string Content { get; set; }
+        public string ContentType { get; set; }
+        public DateTime? DateBegin { get; set; }
+        public DateTime? DateEnd { get; set; }
+        public string Name { get; set; }
+        public RuleStatusDto? Status { get; set; }
+    }
+}

--- a/src/Rules.Framework.WebUI/Dto/RuleDto.cs
+++ b/src/Rules.Framework.WebUI/Dto/RuleDto.cs
@@ -3,6 +3,7 @@ namespace Rules.Framework.WebUI.Dto
     internal sealed class RuleDto
     {
         public ConditionNodeDto Conditions { get; internal set; }
+        public string ContentType { get; internal set; }
         public string DateBegin { get; internal set; }
         public string DateEnd { get; internal set; }
         public string Name { get; internal set; }

--- a/src/Rules.Framework.WebUI/Dto/RuleStatusDto.cs
+++ b/src/Rules.Framework.WebUI/Dto/RuleStatusDto.cs
@@ -2,7 +2,7 @@ namespace Rules.Framework.WebUI.Dto
 {
     internal enum RuleStatusDto : short
     {
-        Inactive,
+        Expired,
         Active,
         Pending,
         Deactivated

--- a/src/Rules.Framework.WebUI/Dto/RuleStatusDtoAnalyzer.cs
+++ b/src/Rules.Framework.WebUI/Dto/RuleStatusDtoAnalyzer.cs
@@ -18,7 +18,7 @@ namespace Rules.Framework.WebUI.Dto
 
             if (dateEnd.Value <= DateTime.UtcNow)
             {
-                return RuleStatusDto.Inactive;
+                return RuleStatusDto.Expired;
             }
 
             return RuleStatusDto.Active;

--- a/src/Rules.Framework.WebUI/Extensions/RuleDtoExtensions.cs
+++ b/src/Rules.Framework.WebUI/Extensions/RuleDtoExtensions.cs
@@ -41,11 +41,12 @@ namespace Rules.Framework.WebUI.Extensions
             };
         }
 
-        public static RuleDto ToRuleDto(this GenericRule rule, IRuleStatusDtoAnalyzer ruleStatusDtoAnalyzer)
+        public static RuleDto ToRuleDto(this GenericRule rule, string ContentType, IRuleStatusDtoAnalyzer ruleStatusDtoAnalyzer)
         {
             return new RuleDto
             {
                 Conditions = rule.RootCondition?.ToConditionNodeDto(),
+                ContentType = ContentType,
                 Priority = rule.Priority,
                 Name = rule.Name,
                 Value = rule.Content,

--- a/src/Rules.Framework.WebUI/Handlers/GetContentTypeHandler.cs
+++ b/src/Rules.Framework.WebUI/Handlers/GetContentTypeHandler.cs
@@ -13,14 +13,14 @@ namespace Rules.Framework.WebUI.Handlers
     {
         private static readonly string[] resourcePath = new[] { "/{0}/api/v1/contentTypes" };
 
-        private readonly IGenericRulesEngine genericRulesEngineAdapter;
+        private readonly IGenericRulesEngine genericRulesEngine;
         private readonly IRuleStatusDtoAnalyzer ruleStatusDtoAnalyzer;
 
-        public GetContentTypeHandler(IGenericRulesEngine rulesEngine,
+        public GetContentTypeHandler(IGenericRulesEngine genericRulesEngine,
             IRuleStatusDtoAnalyzer ruleStatusDtoAnalyzer,
             WebUIOptions webUIOptions) : base(resourcePath, webUIOptions)
         {
-            this.genericRulesEngineAdapter = rulesEngine;
+            this.genericRulesEngine = genericRulesEngine;
             this.ruleStatusDtoAnalyzer = ruleStatusDtoAnalyzer;
         }
 
@@ -30,7 +30,7 @@ namespace Rules.Framework.WebUI.Handlers
         {
             try
             {
-                var contents = this.genericRulesEngineAdapter.GetContentTypes();
+                var contents = this.genericRulesEngine.GetContentTypes();
 
                 var contentTypes = new List<ContentTypeDto>();
                 var index = 0;
@@ -38,7 +38,7 @@ namespace Rules.Framework.WebUI.Handlers
                 {
                     var genericContentType = new GenericContentType { Identifier = identifier };
 
-                    var genericRules = await this.genericRulesEngineAdapter
+                    var genericRules = await this.genericRulesEngine
                         .SearchAsync(new SearchArgs<GenericContentType, GenericConditionType>(genericContentType,
                             DateTime.MinValue,
                             DateTime.MaxValue))

--- a/src/Rules.Framework.WebUI/Handlers/GetIndexPageHandler.cs
+++ b/src/Rules.Framework.WebUI/Handlers/GetIndexPageHandler.cs
@@ -23,7 +23,7 @@ namespace Rules.Framework.WebUI.Handlers
             var path = httpRequest.Path.Value;
             var httpContext = httpRequest.HttpContext;
 
-            if (Regex.IsMatch(path, $"^/?{Regex.Escape(this.webUIOptions.RoutePrefix)}/?$", RegexOptions.IgnoreCase))
+            if (Regex.IsMatch(path, $"^/?{Regex.Escape(this.WebUIOptions.RoutePrefix)}/?$", RegexOptions.IgnoreCase))
             {
                 // Use relative redirect to support proxy environments
                 var relativeIndexUrl = string.IsNullOrEmpty(path) || path.EndsWith("/")
@@ -33,7 +33,7 @@ namespace Rules.Framework.WebUI.Handlers
                 RespondWithRedirect(httpContext.Response, relativeIndexUrl);
             }
 
-            if (Regex.IsMatch(path, $"^/{Regex.Escape(this.webUIOptions.RoutePrefix)}/?index.html$", RegexOptions.IgnoreCase))
+            if (Regex.IsMatch(path, $"^/{Regex.Escape(this.WebUIOptions.RoutePrefix)}/?index.html$", RegexOptions.IgnoreCase))
             {
                 await this.RespondWithIndexHtmlAsync(httpContext.Response, next).ConfigureAwait(false);
             }
@@ -52,8 +52,8 @@ namespace Rules.Framework.WebUI.Handlers
         {
             return new Dictionary<string, string>
             {
-                { "%(DocumentTitle)", this.webUIOptions.DocumentTitle },
-                { "%(HeadContent)", this.webUIOptions.HeadContent }
+                { "%(DocumentTitle)", this.WebUIOptions.DocumentTitle },
+                { "%(HeadContent)", this.WebUIOptions.HeadContent }
             };
         }
 
@@ -66,7 +66,7 @@ namespace Rules.Framework.WebUI.Handlers
 
                 var originalBody = httpResponse.Body;
 
-                using (var stream = this.webUIOptions.IndexStream())
+                using (var stream = this.WebUIOptions.IndexStream())
                 {
                     httpResponse.Body = stream;
                     await next(httpResponse.HttpContext).ConfigureAwait(false);

--- a/src/Rules.Framework.WebUI/Handlers/GetRulesHandler.cs
+++ b/src/Rules.Framework.WebUI/Handlers/GetRulesHandler.cs
@@ -1,9 +1,12 @@
 namespace Rules.Framework.WebUI.Handlers
 {
     using System;
+    using System.Collections.Generic;
     using System.Linq;
     using System.Net;
+    using System.Text.Json;
     using System.Threading.Tasks;
+    using System.Web;
     using Microsoft.AspNetCore.Http;
     using Rules.Framework.Generics;
     using Rules.Framework.WebUI.Dto;
@@ -11,53 +14,42 @@ namespace Rules.Framework.WebUI.Handlers
 
     internal sealed class GetRulesHandler : WebUIRequestHandlerBase
     {
-        private const string dateFormat = "dd/MM/yyyy HH:mm:ss";
         private static readonly string[] resourcePath = new[] { "/{0}/api/v1/rules" };
-        private readonly IGenericRulesEngine rulesEngine;
+        private readonly IGenericRulesEngine genericRulesEngine;
         private readonly IRuleStatusDtoAnalyzer ruleStatusDtoAnalyzer;
 
-        public GetRulesHandler(IGenericRulesEngine rulesEngine, IRuleStatusDtoAnalyzer ruleStatusDtoAnalyzer, WebUIOptions webUIOptions) : base(resourcePath, webUIOptions)
+        public GetRulesHandler(IGenericRulesEngine genericRulesEngine, IRuleStatusDtoAnalyzer ruleStatusDtoAnalyzer, WebUIOptions webUIOptions) : base(resourcePath, webUIOptions)
         {
-            this.rulesEngine = rulesEngine;
+            this.genericRulesEngine = genericRulesEngine;
             this.ruleStatusDtoAnalyzer = ruleStatusDtoAnalyzer;
         }
 
         protected override HttpMethod HttpMethod => HttpMethod.GET;
 
-        protected override async Task HandleRequestAsync(HttpRequest httpRequest, HttpResponse httpResponse, RequestDelegate next)
+        protected override async Task HandleRequestAsync(HttpRequest httpRequest,
+            HttpResponse httpResponse,
+            RequestDelegate next)
         {
-            if (!httpRequest.Query.TryGetValue("contentType", out var contentTypeName))
-            {
-                await this.WriteResponseAsync(httpResponse, new { Message = "contentType is required" }, (int)HttpStatusCode.BadRequest)
-                    .ConfigureAwait(false);
-
-                return;
-            }
+            var rulesFilter = this.GetRulesFilterFromRequest(httpRequest);
 
             try
             {
-                var genericRules = await this.rulesEngine.SearchAsync(
-                    new SearchArgs<GenericContentType, GenericConditionType>(
-                        new GenericContentType { Identifier = contentTypeName },
-                        DateTime.MinValue, DateTime.MaxValue))
-                    .ConfigureAwait(false);
+                var rules = new List<RuleDto>();
 
-                var rules = Enumerable.Empty<RuleDto>();
-
-                var priorityCriteria = this.rulesEngine.GetPriorityCriteria();
-
-                if (genericRules != null && genericRules.Any())
+                if (rulesFilter.ContentType.Equals("all"))
                 {
-                    if (priorityCriteria == PriorityCriterias.BottommostRuleWins)
-                    {
-                        genericRules = genericRules.OrderByDescending(r => r.Priority);
-                    }
-                    else
-                    {
-                        genericRules = genericRules.OrderBy(r => r.Priority);
-                    }
+                    var contents = this.genericRulesEngine.GetContentTypes();
 
-                    rules = genericRules.Select(g => g.ToRuleDto(this.ruleStatusDtoAnalyzer));
+                    foreach (var identifier in contents.Select(c => c.Identifier))
+                    {
+                        var rulesForContentType = await this.GetRulesForContentyType(identifier, rulesFilter).ConfigureAwait(false);
+                        rules.AddRange(rulesForContentType);
+                    }
+                }
+                else
+                {
+                    var rulesForContentType = await this.GetRulesForContentyType(rulesFilter.ContentType, rulesFilter).ConfigureAwait(false);
+                    rules.AddRange(rulesForContentType);
                 }
 
                 await this.WriteResponseAsync(httpResponse, rules, (int)HttpStatusCode.OK).ConfigureAwait(false);
@@ -66,6 +58,76 @@ namespace Rules.Framework.WebUI.Handlers
             {
                 await this.WriteExceptionResponseAsync(httpResponse, ex).ConfigureAwait(false);
             }
+        }
+
+        private RulesFilterDto GetRulesFilterFromRequest(HttpRequest httpRequest)
+        {
+            var parseQueryString = HttpUtility.ParseQueryString(httpRequest.QueryString.Value);
+
+            var rulesFilterAsString = JsonSerializer.Serialize(parseQueryString.Cast<string>().ToDictionary(k => k, v => string.IsNullOrWhiteSpace(parseQueryString[v]) ? null : parseQueryString[v]));
+            var rulesFilter = JsonSerializer.Deserialize<RulesFilterDto>(rulesFilterAsString, this.SerializerOptions);
+
+            rulesFilter.ContentType = string.IsNullOrWhiteSpace(rulesFilter.ContentType) ? "all" : rulesFilter.ContentType;
+
+            rulesFilter.DateEnd ??= DateTime.MaxValue;
+
+            rulesFilter.DateBegin ??= DateTime.MinValue;
+
+            return rulesFilter;
+        }
+
+        private async Task<IEnumerable<RuleDto>> GetRulesForContentyType(string identifier, RulesFilterDto rulesFilter)
+        {
+            var genericRules = await this.genericRulesEngine.SearchAsync(
+                                       new SearchArgs<GenericContentType, GenericConditionType>(
+                                           new GenericContentType { Identifier = identifier },
+                                           rulesFilter.DateBegin.Value, rulesFilter.DateEnd.Value))
+                                       .ConfigureAwait(false);
+
+            var priorityCriteria = this.genericRulesEngine.GetPriorityCriteria();
+
+            if (genericRules != null && genericRules.Any())
+            {
+                if (priorityCriteria == PriorityCriterias.BottommostRuleWins)
+                {
+                    genericRules = genericRules.OrderByDescending(r => r.Priority);
+                }
+                else
+                {
+                    genericRules = genericRules.OrderBy(r => r.Priority);
+                }
+
+                return genericRules
+                    .Select(g => g.ToRuleDto(this.ruleStatusDtoAnalyzer))
+                    .Where(d =>
+                    {
+                        if (string.IsNullOrWhiteSpace(rulesFilter.Content))
+                        {
+                            return true;
+                        }
+
+                        return JsonSerializer.Serialize(d.Value).Contains(rulesFilter.Content, StringComparison.OrdinalIgnoreCase);
+                    })
+                    .Where(d =>
+                    {
+                        if (string.IsNullOrWhiteSpace(rulesFilter.Name))
+                        {
+                            return true;
+                        }
+
+                        return d.Name.Contains(rulesFilter.Name, StringComparison.OrdinalIgnoreCase);
+                    })
+                    .Where(d =>
+                    {
+                        if (rulesFilter.Status is null)
+                        {
+                            return true;
+                        }
+
+                        return d.Status.Equals(rulesFilter.Status.ToString());
+                    });
+            }
+            return Enumerable.Empty<RuleDto>();
         }
     }
 }

--- a/src/Rules.Framework.WebUI/Handlers/GetRulesHandler.cs
+++ b/src/Rules.Framework.WebUI/Handlers/GetRulesHandler.cs
@@ -32,6 +32,14 @@ namespace Rules.Framework.WebUI.Handlers
         {
             var rulesFilter = this.GetRulesFilterFromRequest(httpRequest);
 
+            if (!IsValidFilterDates(rulesFilter))
+            {
+                await this.WriteResponseAsync(httpResponse, new { Message = "Date begin cannot be greater than after" }, (int)HttpStatusCode.BadRequest)
+                   .ConfigureAwait(false);
+
+                return;
+            }
+
             try
             {
                 var rules = new List<RuleDto>();
@@ -58,6 +66,13 @@ namespace Rules.Framework.WebUI.Handlers
             {
                 await this.WriteExceptionResponseAsync(httpResponse, ex).ConfigureAwait(false);
             }
+        }
+
+        private static bool IsValidFilterDates(RulesFilterDto rulesFilter)
+        {
+            return (rulesFilter.DateBegin is null
+                || rulesFilter.DateEnd is null) ||
+                (rulesFilter.DateBegin <= rulesFilter.DateEnd);
         }
 
         private IEnumerable<RuleDto> ApplyFilters(RulesFilterDto rulesFilter, IEnumerable<RuleDto> genericRulesDto)

--- a/src/Rules.Framework.WebUI/WebUIRequestHandlerBase.cs
+++ b/src/Rules.Framework.WebUI/WebUIRequestHandlerBase.cs
@@ -13,14 +13,13 @@ namespace Rules.Framework.WebUI
 
     internal abstract class WebUIRequestHandlerBase : IHttpRequestHandler
     {
-        protected readonly WebUIOptions webUIOptions;
-
-        private readonly JsonSerializerOptions SerializerOptions;
+        protected readonly JsonSerializerOptions SerializerOptions;
+        protected readonly WebUIOptions WebUIOptions;
 
         protected WebUIRequestHandlerBase(string[] resourcePath, WebUIOptions webUIOptions)
         {
             this.ResourcePath = resourcePath;
-            this.webUIOptions = webUIOptions;
+            this.WebUIOptions = webUIOptions;
             this.SerializerOptions = new JsonSerializerOptions
             {
                 PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
@@ -52,7 +51,7 @@ namespace Rules.Framework.WebUI
         {
             var resource = httpRequest.Path.ToUriComponent();
 
-            var resourcesPath = this.ResourcePath.Select(r => string.Format(r, this.webUIOptions.RoutePrefix));
+            var resourcesPath = this.ResourcePath.Select(r => string.Format(r, this.WebUIOptions.RoutePrefix));
 
             if (!resourcesPath.Contains(resource))
             {

--- a/src/Rules.Framework.WebUI/index.html
+++ b/src/Rules.Framework.WebUI/index.html
@@ -162,31 +162,53 @@
                             </legend>
                             <div class="collapse show" id="filterRules">
                                 <form class="row g-3" novalidate>
-                                    <div class="col-md-3">
-                                        <label for="contentTypesSelect" class="col-form-label-sm">Content Type</label>
-                                        <select class="form-select form-select-sm" id="contentTypesSelect" required>
-                                            <option value="">Loading...</option>
-                                        </select>
-                                    </div>
-                                    <div class="col-md-3">
-                                        <label for="ruleNameSearch" class="col-form-label-sm">Name</label>
-                                        <input class="form-control form-control-sm" id="ruleNameSearch" />
-                                    </div>
+                                    <div class="row" style="display: flex;
+                                            flex-direction: row;
+                                            justify-content: space-between;">
 
-                                    <div class="col-md-3">
-                                        <label for="ruleValueSearch" class="col-form-label-sm">Content</label>
-                                        <input class="form-control form-control-sm" id="ruleValueSearch" />
+                                        <div class="col-md-4">
+                                            <label for="contentTypesSelect" class="col-form-label-sm">Content Type</label>
+                                            <select class="form-select form-select-sm" id="contentTypesSelect" required>
+                                                <option value="">Loading...</option>
+                                            </select>
+                                        </div>
+                                        <div class="col-md-4">
+                                            <label for="ruleStatusesSelect" class="col-form-label-sm">Status</label>
+                                            <select class="form-select form-select-sm" id="ruleStatusesSelect">
+                                                <option value="">Choose Status...</option>
+                                                <option value="active">Active</option>
+                                                <option value="expired">Expired</option>
+                                                <option value="pending">Pending</option>
+                                                <option value="deactivated">Deactivated</option>
+                                            </select>
+                                        </div>
+                                        
+                                        <div class="col-md-2">
+                                            <label for="dateBeginSearch" class="col-form-label-sm">Before</label>
+                                            <input class="form-control form-control-sm" type="date" id="dateBeginSearch" />
+                                        </div>
+                                        <div class="col-md-2">
+                                            <label for="dateEndSearch" class="col-form-label-sm">After</label>
+                                            <input class="form-control form-control-sm" type="date" id="dateEndSearch" />
+                                        </div>
                                     </div>
-
-                                    <div class="col-md-2">
-                                        <label for="ruleStatusesSelect" class="col-form-label-sm">Status</label>
-                                        <select class="form-select form-select-sm" id="ruleStatusesSelect">
-                                            <option value="">Choose Status...</option>
-                                            <option value="active">Active</option>
-                                            <option value="inactive">Inactive</option>
-                                            <option value="pending">Pending</option>
-                                            <option value="deactivated">Deactivated</option>
-                                        </select>
+                                    <div class="row" style="display: flex;
+                                            flex-direction: row;
+                                            justify-content: space-between;">
+                                        <div class="col-md-5">
+                                            <label for="ruleNameSearch" class="col-form-label-sm">Name</label>
+                                            <input class="form-control form-control-sm" id="ruleNameSearch" />
+                                        </div>
+                                        <div class="col-md-5">
+                                            <label for="ruleValueSearch" class="col-form-label-sm">Content</label>
+                                            <input class="form-control form-control-sm" id="ruleValueSearch" />
+                                        </div>
+                                        <div class="col-md-2" style="
+                                                display: flex;                                                                                                
+                                                justify-content: flex-end;
+                                                align-items: flex-end;">
+                                            <button id="ruleSearch" type="button" class="btn btn-dark"><i class="glyphicon glyphicon-search"></i> Search</button>
+                                        </div>
                                     </div>
                                 </form>
                             </div>
@@ -279,9 +301,7 @@
             })
         }
 
-        function setRulesPagination(dataSource) {
-            dataSource = applyRulesFilter(dataSource);
-
+        function setRulesPagination(dataSource) {            
             $('#rules_pagination').pagination({
                 dataSource: dataSource,
                 pageSize: pageSize,
@@ -357,7 +377,7 @@
                 trHTML += '<td style="text-align: center;"><span class="badge bg-primary" style="font-size:1em!important; color: #373b3e !important;background-color: #cdced7 !important;">' + item.rulesCount + '<span></td>';
                 trHTML += '<td style="text-align: center;"><button style="font-size:.875rem" type="button" class="btn btn-dark rules"  ';
                 trHTML += 'title="Rules" id="b' + item.name + '">';
-                trHTML += '<span class="glyphicon glyphicon-search" id="' + item.name + '"></span>';
+                trHTML += '<span class="glyphicon glyphicon-log-in" id="' + item.name + '"></span>';
                 trHTML += '</button></td>';
                 trHTML += '</tr>';
             });
@@ -425,6 +445,7 @@
 
             return html;
         }
+
         function recursiveStringView(node, logicalOperator, isFirst, tabsLeft) {
             let html = '';                        
             if (!node) {
@@ -530,52 +551,40 @@
             return html;
         }
 
-        function applyRulesFilter(dataSource) {
-            if (ruleFilter.name) {
-                dataSource = dataSource.filter(function (r) {
-                    return r.name.toLowerCase().includes(ruleFilter.name.toLowerCase());
-                });
-            }
-
-            if (ruleFilter.status) {
-                dataSource = dataSource.filter(function (r) {
-                    return r.status.toLowerCase() == ruleFilter.status.toLowerCase();
-                });
-            }
-
-            if (ruleFilter.value) {
-                dataSource = dataSource.filter(function (r) {
-                    return JSON.stringify(r.value).toLowerCase().includes(ruleFilter.value.toLowerCase());
-                });
-            }
-
-            return dataSource;
-        }
-
-        function setContentTypesSelectEvent(){
-            $("#contentTypesSelect").on('change', function (){
+        function setRuleSearchClickEvent(){
+            $("#ruleSearch").on('click', function (){
                 $('#rules_table').html('');
-                let contentTypeSelected = $(this).children("option:selected").val();
-                contentType = '';
-
-                if (contentTypeSelected)
-                {
-                    $("#loading").show();
-                    $.ajax({
-                        url: "api/v1/rules?contentType=" + contentTypeSelected,
-                        success: function (response) {
-                            rules = response;
-
-                            
-                            setRulesPagination(response);
-                        },
-                        error: function (error) {
-                            $('#loading').hide();
-                            $('#errorModal').modal('show');
-                            $('#errorBody').html('<pre>' + JSON.stringify(error, null, '\t') + '</pre>');
-                        }
-                    });
-                }
+                const contentType = $('#contentTypesSelect').children("option:selected").val();
+                const status = $('#ruleStatusesSelect').children("option:selected").val();
+                const name = $('#ruleNameSearch').val();
+                const dateBegin = $('#dateBeginSearch').val();
+                const dateEnd = $('#dateEndSearch').val();
+                const content = $('#ruleValueSearch').val();                
+                                
+                                
+                $("#loading").show();
+                $.ajax({
+                    url: "api/v1/rules",
+                    data: jQuery.param(
+                        {
+                            contentType: contentType ?? null,
+                            content: content ?? null,
+                            dateBegin: dateBegin ?? null,
+                            dateEnd: dateEnd ?? null,
+                            status: status ?? null,
+                            name: name ?? null
+                        }),
+                    success: function (response) {
+                        rules = response;                            
+                        setRulesPagination(response);
+                    },
+                    error: function (error) {
+                        $('#loading').hide();
+                        $('#errorModal').modal('show');
+                        $('#errorBody').html('<pre>' + JSON.stringify(error, null, '\t') + '</pre>');
+                    }
+                });
+                
             });
 
 
@@ -618,21 +627,7 @@
                 setContentTypesPagination(contentTypes);
             });
 
-            $('#ruleStatusesSelect').on('change', function (e) {
-                ruleFilter.status = $(this).children("option:selected").val();
-                setRulesPagination(rules);
-            });
-
-            $('#ruleNameSearch').on('input', function (e) {
-                ruleFilter.name = $(this).val();
-                setRulesPagination(rules);
-            });
-
-            $('#ruleValueSearch').on('input', function (e) {
-                ruleFilter.value = $(this).val();
-                setRulesPagination(rules);
-            });
-
+            
             $('#contentTypeSearch').on('input', function (e) {
                 const contentTypeValue = $(this).val();
 
@@ -647,6 +642,7 @@
 
                 let filename = 'rules_as_json';
                 const contentTypeSelected = $('#contentTypesSelect').children("option:selected").val();
+
                 if (contentTypeSelected) {
                     filename += '_' + contentTypeSelected;
                 }
@@ -711,7 +707,7 @@
                 if (d.currentTarget.id == "rules") {
                     $('#rules_table').html('');
                     setRulesPagination([]);
-                    setContentTypesSelectEvent();
+                    setRuleSearchClickEvent();
 
 
                     let $dropdown = $("#contentTypesSelect");
@@ -720,7 +716,7 @@
                         url: "api/v1/contentTypes",
                         success: function (response) {
                             contentTypes = response;
-                            $dropdown.html('<option value="">Choose ContentType...</option>');
+                            $dropdown.html('<option value="">Choose ContentType...</option>');                            
                             $.each(response, function (i, item) {
                                 if (contentType == item.name || contentType == 'b' + item.name) {
                                     $dropdown.append($("<option>", {

--- a/src/Rules.Framework.WebUI/index.html
+++ b/src/Rules.Framework.WebUI/index.html
@@ -548,7 +548,11 @@
             let ruleNameSearchTimeout = null;
 
             $('#ruleNameSearch').keyup(function (event) {
-                if (event.keyCode == 13 && $('#rules') && $('#rules').hasClass('active')) {                    
+                let keyCode = event.keyCode || event.which
+                
+                if (keyCode == 13) {
+                    event.preventDefault();
+                    clearTimeout(ruleValueSearchTimeout);
                     return false;
                 }
 
@@ -558,8 +562,12 @@
 
             let ruleValueSearchTimeout = null;
 
-            $('#ruleValueSearch').keyup(function () {
-                if (event.keyCode == 13 && $('#rules') && $('#rules').hasClass('active')) {
+            $('#ruleValueSearch').keyup(function (event) {
+                let keyCode = event.keyCode || event.which
+
+                if (event.keyCode == 13) {                    
+                    event.preventDefault();
+                    clearTimeout(ruleValueSearchTimeout);
                     return false;
                 }
                 clearTimeout(ruleValueSearchTimeout);

--- a/src/Rules.Framework.WebUI/index.html
+++ b/src/Rules.Framework.WebUI/index.html
@@ -193,21 +193,14 @@
                                         </div>
                                     </div>
                                     <div class="row" style="display: flex;
-                                            flex-direction: row;
-                                            justify-content: space-between;">
-                                        <div class="col-md-5">
+                                            flex-direction: row;">
+                                        <div class="col-md-4">
                                             <label for="ruleNameSearch" class="col-form-label-sm">Name</label>
                                             <input class="form-control form-control-sm" id="ruleNameSearch" />
                                         </div>
-                                        <div class="col-md-5">
+                                        <div class="col-md-4">
                                             <label for="ruleValueSearch" class="col-form-label-sm">Content</label>
                                             <input class="form-control form-control-sm" id="ruleValueSearch" />
-                                        </div>
-                                        <div class="col-md-2" style="
-                                                display: flex;                                                                                                
-                                                justify-content: flex-end;
-                                                align-items: flex-end;">
-                                            <button id="rulesSearch" type="button" class="btn btn-dark"><i class="glyphicon glyphicon-search"></i> Search</button>
                                         </div>
                                     </div>
                                 </form>
@@ -271,22 +264,18 @@
     <script src="bootstrap/dist/bootstrap.bundle.min.js"></script>
 
     <script>
-        rules = [];
-        contentTypes = [];
-        contentType = '';
-        priority = '';
-        conditions = [];
-        pageSize = 10;
-        contentTypesFilter = {
+        let rules = [];
+        let contentTypes = [];
+        let contentType = '';
+        let priority = '';
+        let conditions = [];
+        let pageSize = 10;
+        let contentTypesFilter = {
             name: '',
             onlyWithRules: false
         };
-        ruleFilter = {
-            status: '',
-            name: '',
-            value: ''
-        };
-
+        let timeoutToSearch = 2000;
+                
         function setContentTypesPagination(dataSource) {
 
             dataSource = applyContentTypesFilter(dataSource);
@@ -403,8 +392,7 @@
                 if (contentTypeClicked)
                 {
                     contentType = contentTypeClicked;
-                    $('#rules').click();
-                    $('#rulesSearch').click();
+                    $('#rules').click();                    
                 }
             });
         }
@@ -553,8 +541,37 @@
             return html;
         }
 
-        function setRulesSearchClickEvent(){
-            $("#rulesSearch").on('click', function (){
+        function setSearchEvents(){
+            $('#contentTypesSelect').on('change', search);
+            $('#ruleStatusesSelect').on('change', search);
+            
+            let ruleNameSearchTimeout = null;
+
+            $('#ruleNameSearch').keyup(function (event) {
+                if (event.keyCode == 13 && $('#rules') && $('#rules').hasClass('active')) {                    
+                    return false;
+                }
+
+                clearTimeout(ruleNameSearchTimeout);
+                ruleNameSearchTimeout = setTimeout(search, timeoutToSearch);
+            });
+
+            let ruleValueSearchTimeout = null;
+
+            $('#ruleValueSearch').keyup(function () {
+                if (event.keyCode == 13 && $('#rules') && $('#rules').hasClass('active')) {
+                    return false;
+                }
+                clearTimeout(ruleValueSearchTimeout);
+                ruleValueSearchTimeout = setTimeout(search, timeoutToSearch);
+            });
+                                              
+            
+            $('#dateBeginSearch').on('change', search);
+            $('#dateEndSearch').on('change', search);
+        }
+
+        function search() {                
                 $('#rules_table').html('');
                 const contentType = $('#contentTypesSelect').children("option:selected").val();
                 const status = $('#ruleStatusesSelect').children("option:selected").val();
@@ -586,10 +603,6 @@
                         $('#errorBody').html('<pre>' + JSON.stringify(error, null, '\t') + '</pre>');
                     }
                 });
-                
-            });
-
-
         }
 
         function applyContentTypesFilter(dataSource) {
@@ -607,10 +620,10 @@
         }
 
         $(document).ready(() => {
-            $(document).keypress(function (event) {     
+            $(document).keypress(function (event) {
                 if (event.keyCode == 13 && $('#rules') && $('#rules').hasClass('active')) {
                     event.preventDefault();
-                    $('#rulesSearch').click();
+                    search();
                     return false;
                 }
             });
@@ -717,8 +730,8 @@
                 if (d.currentTarget.id == "rules") {
                     $('#rules_table').html('');
                     setRulesPagination([]);
-                    setRulesSearchClickEvent();
-
+                    setSearchEvents();
+                    
 
                     let $dropdown = $("#contentTypesSelect");
                     $dropdown.html('<option value="">Loading...</option>');
@@ -743,11 +756,7 @@
                                     }));
                                 }
                             });
-
-                            if (contentType)
-                            {
-                                $dropdown.change();
-                            }
+                            $dropdown.change();                            
                         },
                         error: function (error) {
                             openError(error);

--- a/src/Rules.Framework.WebUI/index.html
+++ b/src/Rules.Framework.WebUI/index.html
@@ -542,30 +542,42 @@
         }
 
         function setSearchEvents(){
-            $('#contentTypesSelect').on('change', search);
-            $('#ruleStatusesSelect').on('change', search);
-            
             let ruleNameSearchTimeout = null;
+            let ruleValueSearchTimeout = null;
+                        
+            $('#contentTypesSelect').on('change', search);
+
+            $('#ruleStatusesSelect').on('change', search);
+
+            $('#ruleNameSearch').on('change', function (){
+                clearTimeout(ruleNameSearchTimeout);
+                search();
+            });
+            $('#ruleValueSearch').on('change', function () {
+                clearTimeout(ruleValueSearchTimeout);
+                search();
+            });
+            
+            
+            const unbouncedKeyCodes = [13, 9]; //13 = enter, 9 = tab
 
             $('#ruleNameSearch').keyup(function (event) {
-                let keyCode = event.keyCode || event.which
+                let keyCode = event.keyCode || event.which;
                 
-                if (keyCode == 13) {
+                if (unbouncedKeyCodes.includes(keyCode)) {
                     event.preventDefault();
-                    clearTimeout(ruleValueSearchTimeout);
+                    clearTimeout(ruleNameSearchTimeout);
                     return false;
                 }
 
                 clearTimeout(ruleNameSearchTimeout);
                 ruleNameSearchTimeout = setTimeout(search, timeoutToSearch);
             });
-
-            let ruleValueSearchTimeout = null;
-
+                        
             $('#ruleValueSearch').keyup(function (event) {
-                let keyCode = event.keyCode || event.which
+                let keyCode = event.keyCode || event.which;
 
-                if (keyCode == 13) {                    
+                if (unbouncedKeyCodes.includes(keyCode)) {                    
                     event.preventDefault();
                     clearTimeout(ruleValueSearchTimeout);
                     return false;
@@ -575,42 +587,76 @@
             });
                                               
             
-            $('#dateBeginSearch').on('change', search);
-            $('#dateEndSearch').on('change', search);
+            $('#dateBeginSearch').on('change', function (event) {                
+                if (areDatesValid()) {
+                    search();
+                    return;
+                }
+                $('#dateBeginSearch').val('');
+            });
+            $('#dateEndSearch').on('change', function () {
+                if (areDatesValid()) {
+                    search();
+                    return;
+                }
+                $('#dateEndSearch').val('');
+            });
         }
 
-        function search() {                
-                $('#rules_table').html('');
-                const contentType = $('#contentTypesSelect').children("option:selected").val();
-                const status = $('#ruleStatusesSelect').children("option:selected").val();
-                const name = $('#ruleNameSearch').val();
-                const dateBegin = $('#dateBeginSearch').val();
-                const dateEnd = $('#dateEndSearch').val();
-                const content = $('#ruleValueSearch').val();                
+        let executingSearch = false;
+
+        function areDatesValid() {
+            let from = $("#dateBeginSearch").val();
+            let to = $("#dateEndSearch").val();
+
+            if (Date.parse(from) > Date.parse(to)) {
+                $('#errorModal').modal('show');
+                $('#errorBody').html('<pre> Invalid date range </pre>');                
+                return false;
+            }
+
+            return true;
+        }
+        
+
+        function search() {
+            if (executingSearch) {
+                return;
+            }
+            executingSearch = true;
+            $('#rules_table').html('');
+            const contentType = $('#contentTypesSelect').children("option:selected").val();
+            const status = $('#ruleStatusesSelect').children("option:selected").val();
+            const name = $('#ruleNameSearch').val();
+            const dateBegin = $('#dateBeginSearch').val();
+            const dateEnd = $('#dateEndSearch').val();
+            const content = $('#ruleValueSearch').val();                
                                 
                                 
-                $("#loading").show();
-                $.ajax({
-                    url: "api/v1/rules",
-                    data: jQuery.param(
-                        {
-                            contentType: contentType ?? null,
-                            content: content ?? null,
-                            dateBegin: dateBegin ?? null,
-                            dateEnd: dateEnd ?? null,
-                            status: status ?? null,
-                            name: name ?? null
-                        }),
-                    success: function (response) {
-                        rules = response;                            
-                        setRulesPagination(response);
-                    },
-                    error: function (error) {
-                        $('#loading').hide();
-                        $('#errorModal').modal('show');
-                        $('#errorBody').html('<pre>' + JSON.stringify(error, null, '\t') + '</pre>');
-                    }
-                });
+            $("#loading").show();
+            $.ajax({
+                url: "api/v1/rules",
+                data: jQuery.param(
+                    {
+                        contentType: contentType ?? null,
+                        content: content ?? null,
+                        dateBegin: dateBegin ?? null,
+                        dateEnd: dateEnd ?? null,
+                        status: status ?? null,
+                        name: name ?? null
+                    }),
+                success: function (response) {
+                    executingSearch = false;
+                    rules = response;                            
+                    setRulesPagination(response);
+                },
+                error: function (error) {
+                    executingSearch = false;
+                    $('#loading').hide();
+                    $('#errorModal').modal('show');
+                    $('#errorBody').html('<pre>' + JSON.stringify(error, null, '\t') + '</pre>');
+                }
+            });
         }
 
         function applyContentTypesFilter(dataSource) {
@@ -627,7 +673,7 @@
             return dataSource;
         }
 
-        $(document).ready(() => {
+        $(document).ready(() => {            
             $(document).keypress(function (event) {
                 if (event.keyCode == 13 && $('#rules') && $('#rules').hasClass('active')) {
                     event.preventDefault();

--- a/src/Rules.Framework.WebUI/index.html
+++ b/src/Rules.Framework.WebUI/index.html
@@ -240,6 +240,7 @@
                                 <thead style="border-bottom: 2px solid currentcolor;">
                                     <tr>
                                         <th scope="col" width="2%">Priority</th>
+                                        <th scope="col" width="15%">Content Type</th>
                                         <th scope="col" width="20%">Name</th>
                                         <th scope="col" width="10%" nowrap style="text-align: center;">Date Begin</th>
                                         <th scope="col" width="10%" nowrap style="text-align: center;">Date End</th>
@@ -348,7 +349,7 @@
                         icon = 'glyphicon glyphicon-exclamation-sign';
                 }
 
-                trHTML += '<tr><th scope="row">' + item.priority + ' </th><td>' + item.name + '</td>';
+                trHTML += '<tr><th scope="row">' + item.priority + ' </th><td>' + item.contentType + '</td><td>' + item.name + '</td>';
                 trHTML += '<td style="text-align: center;" nowrap>' + item.dateBegin + '</td><td style="text-align: center;" nowrap> ' + dateEnd + '</td>';
                 trHTML += '<td>' + JSON.stringify(item.value) + '</td>';
                 trHTML += '<td style="text-align: center;"><span class="' + labelColor + '" style="' + style + '"> ';

--- a/src/Rules.Framework.WebUI/index.html
+++ b/src/Rules.Framework.WebUI/index.html
@@ -109,7 +109,7 @@
                                 </button>
                             </legend>
                             <div class="collapse show" id="filterContentTypes">
-                                <form novalidate>
+                                <form novalidate onSubmit="return false;">
                                     <div class="col-md-12" style="display: flex; align-items: flex-end;">
                                         <div class="col-md-5" style="margin-right: 12px;">
                                             <label for="contentTypeSearch" class="col-form-label-sm">Name</label>
@@ -161,7 +161,7 @@
                                 </button>
                             </legend>
                             <div class="collapse show" id="filterRules">
-                                <form class="row g-3" novalidate>
+                                <form class="row g-3" novalidate onSubmit="return false;">
                                     <div class="row" style="display: flex;
                                             flex-direction: row;
                                             justify-content: space-between;">
@@ -207,7 +207,7 @@
                                                 display: flex;                                                                                                
                                                 justify-content: flex-end;
                                                 align-items: flex-end;">
-                                            <button id="ruleSearch" type="button" class="btn btn-dark"><i class="glyphicon glyphicon-search"></i> Search</button>
+                                            <button id="rulesSearch" type="button" class="btn btn-dark"><i class="glyphicon glyphicon-search"></i> Search</button>
                                         </div>
                                     </div>
                                 </form>
@@ -404,6 +404,7 @@
                 {
                     contentType = contentTypeClicked;
                     $('#rules').click();
+                    $('#rulesSearch').click();
                 }
             });
         }
@@ -552,8 +553,8 @@
             return html;
         }
 
-        function setRuleSearchClickEvent(){
-            $("#ruleSearch").on('click', function (){
+        function setRulesSearchClickEvent(){
+            $("#rulesSearch").on('click', function (){
                 $('#rules_table').html('');
                 const contentType = $('#contentTypesSelect').children("option:selected").val();
                 const status = $('#ruleStatusesSelect').children("option:selected").val();
@@ -606,6 +607,14 @@
         }
 
         $(document).ready(() => {
+            $(document).keypress(function (event) {     
+                if (event.keyCode == 13 && $('#rules') && $('#rules').hasClass('active')) {
+                    event.preventDefault();
+                    $('#rulesSearch').click();
+                    return false;
+                }
+            });
+
             $('#conditionsAsColumn').on('change', function (e) {
                 const checked = $(this).prop('checked');
 
@@ -708,7 +717,7 @@
                 if (d.currentTarget.id == "rules") {
                     $('#rules_table').html('');
                     setRulesPagination([]);
-                    setRuleSearchClickEvent();
+                    setRulesSearchClickEvent();
 
 
                     let $dropdown = $("#contentTypesSelect");
@@ -750,6 +759,8 @@
 
 
         });
+
+       
     </script>
 
     <div class="modal fade" id="errorModal">

--- a/src/Rules.Framework.WebUI/index.html
+++ b/src/Rules.Framework.WebUI/index.html
@@ -565,7 +565,7 @@
             $('#ruleValueSearch').keyup(function (event) {
                 let keyCode = event.keyCode || event.which
 
-                if (event.keyCode == 13) {                    
+                if (keyCode == 13) {                    
                     event.preventDefault();
                     clearTimeout(ruleValueSearchTimeout);
                     return false;

--- a/tests/Rules.Framework.WebUI.Tests/Extensions/RuleDtoExtensionsTests.cs
+++ b/tests/Rules.Framework.WebUI.Tests/Extensions/RuleDtoExtensionsTests.cs
@@ -20,9 +20,9 @@ namespace Rules.Framework.WebUI.Tests.Extensions
         {
             // Arrange
             var genericRule = new GenericRule();
-
+            var contentType = "contentType";
             // Act
-            var ruleDto = genericRule.ToRuleDto(this.ruleStatusDtoAnalyzer);
+            var ruleDto = genericRule.ToRuleDto(contentType, this.ruleStatusDtoAnalyzer);
 
             // Assert
             ruleDto.Should().NotBeNull();

--- a/tests/Rules.Framework.WebUI.Tests/Handlers/GetRulesHandlerTests.cs
+++ b/tests/Rules.Framework.WebUI.Tests/Handlers/GetRulesHandlerTests.cs
@@ -29,7 +29,6 @@ namespace Rules.Framework.WebUI.Tests.Handlers
         [Theory]
         [InlineData("POST", "/rules/api/v1/rules", false, null)]
         [InlineData("GET", "/rules/api/v1/contentTypes", false, null)]
-        [InlineData("GET", "/rules/api/v1/rules", true, HttpStatusCode.BadRequest)]
         [InlineData("GET", "/rules/api/v1/rules", true, HttpStatusCode.OK)]
         [InlineData("GET", "/rules/api/v1/rules", true, HttpStatusCode.InternalServerError)]
         public async Task HandleRequestAsync_Validation(string httpMethod, string resourcePath,
@@ -43,6 +42,7 @@ namespace Rules.Framework.WebUI.Tests.Handlers
             if (statusCode == HttpStatusCode.OK || statusCode == HttpStatusCode.InternalServerError)
             {
                 verifySearchAsync = true;
+
                 httpContext.Request.QueryString = new QueryString("?contentType=1");
 
                 if (statusCode == HttpStatusCode.OK)


### PR DESCRIPTION
## Description

- Added Web UI able to set cutover dates for the rules 
- Content type is no longer required, you may search into all rules 
- Changed rules status from inactive to expired
- Moved to the backend the responsibility to filter the rules

![image](https://github.com/Farfetch/rules-framework/assets/1099060/61ebdbf9-03cf-422d-9130-cd44ff3bda95)

Related to issue #105 

## Change checklist

- [ ] Code follows the [code rules guidelines](../CONTRIBUTING.md#code-rules) of this project
- [ ] Commit messages follow the [commit rules](../CONTRIBUTING.md#commit-rules) of this project
- [x] I have self-reviewed my changes before submitting this pull request
- [ ] I have covered new/changed code with new tests and/or adjusted existent ones
- [ ] I have made changes necessary to update the documentation accordingly

Please also check the [_I want to contribute_](../CONTRIBUTING.md#i-want-to-contribute) guidelines and make sure you have done accordingly.

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)