### PR TITLE
Operators.In and Operators.NotIn with not working properly when trying to match the rule setting the condition value as null

### DIFF
--- a/src/Rules.Framework/Builder/RulesEngineOptionsValidator.cs
+++ b/src/Rules.Framework/Builder/RulesEngineOptionsValidator.cs
@@ -17,15 +17,15 @@ namespace Rules.Framework.Builder
             ValidateDataTypeDefault(
                 rulesEngineOptions.DataTypeDefaults,
                 DataTypes.Boolean,
-                value => value != null && bool.TryParse(value.ToString(), out bool boolRes));
+                value => value != null && bool.TryParse(value.ToString(), out bool _));
             ValidateDataTypeDefault(
                 rulesEngineOptions.DataTypeDefaults,
                 DataTypes.Decimal,
-                value => value != null && decimal.TryParse(value.ToString(), NumberStyles.None, CultureInfo.InvariantCulture, out decimal decimalRes));
+                value => value != null && decimal.TryParse(value.ToString(), NumberStyles.None, CultureInfo.InvariantCulture, out decimal _));
             ValidateDataTypeDefault(
                 rulesEngineOptions.DataTypeDefaults,
                 DataTypes.Integer,
-                value => value != null && int.TryParse(value.ToString(), NumberStyles.None, CultureInfo.InvariantCulture, out int intRes));
+                value => value != null && int.TryParse(value.ToString(), NumberStyles.None, CultureInfo.InvariantCulture, out int _));
             ValidateDataTypeDefault(
                 rulesEngineOptions.DataTypeDefaults,
                 DataTypes.String,
@@ -33,19 +33,19 @@ namespace Rules.Framework.Builder
             ValidateDataTypeDefault(
                 rulesEngineOptions.DataTypeDefaults,
                 DataTypes.ArrayBoolean,
-                value => value is IEnumerable<bool>);
+                value => value is bool);
             ValidateDataTypeDefault(
                 rulesEngineOptions.DataTypeDefaults,
                 DataTypes.ArrayDecimal,
-                value => value is IEnumerable<decimal>);
+                value => value is decimal);
             ValidateDataTypeDefault(
                 rulesEngineOptions.DataTypeDefaults,
                 DataTypes.ArrayInteger,
-                value => value is IEnumerable<int>);
+                value => value is int);
             ValidateDataTypeDefault(
                 rulesEngineOptions.DataTypeDefaults,
                 DataTypes.ArrayString,
-                value => value is IEnumerable<string>);
+                value => value is string);
 
         }
 

--- a/src/Rules.Framework/RulesEngineOptions.cs
+++ b/src/Rules.Framework/RulesEngineOptions.cs
@@ -2,7 +2,6 @@ namespace Rules.Framework
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
     using Rules.Framework.Core;
 
     /// <summary>
@@ -21,7 +20,7 @@ namespace Rules.Framework
         public IDictionary<DataTypes, object> DataTypeDefaults { get; }
 
         /// <summary>
-        /// Gets or sets wether rules' conditions is enabled or not.
+        /// Gets or sets whether rules' conditions is enabled or not.
         /// </summary>
         public bool EnableCompilation { get; set; }
 
@@ -57,7 +56,7 @@ namespace Rules.Framework
         /// </summary>
         /// <remarks>
         /// <para>MissingConditionBehavior = UseDataTypeDefault</para>
-        /// <para>PriotityCriteria = TopmostRuleWins</para>
+        /// <para>PriorityCriteria = TopmostRuleWins</para>
         /// <para>DataTypes.Boolean default = default(bool)</para>
         /// <para>DataTypes.Decimal default = default(decimal)</para>
         /// <para>DataTypes.Integer default = default(int)</para>
@@ -66,21 +65,23 @@ namespace Rules.Framework
         /// <returns></returns>
         public static RulesEngineOptions NewWithDefaults()
         {
-            RulesEngineOptions rulesEngineOptions = new RulesEngineOptions
+            RulesEngineOptions rulesEngineOptions = new()
             {
                 MissingConditionBehavior = MissingConditionBehaviors.UseDataTypeDefault,
-                PriorityCriteria = PriorityCriterias.TopmostRuleWins
+                PriorityCriteria = PriorityCriterias.TopmostRuleWins,
+                DataTypeDefaults =
+                    {
+                        [DataTypes.Boolean] = default(bool),
+                        [DataTypes.Decimal] = default(decimal),
+                        [DataTypes.Integer] = default(int),
+                        [DataTypes.String] = string.Empty,
+                        [DataTypes.ArrayBoolean] = default(bool),
+                        [DataTypes.ArrayDecimal] = default(decimal),
+                        [DataTypes.ArrayInteger] = default(int),
+                        [DataTypes.ArrayString] = string.Empty,
+                    },
             };
 
-            rulesEngineOptions.DataTypeDefaults[DataTypes.Boolean] = default(bool);
-            rulesEngineOptions.DataTypeDefaults[DataTypes.Decimal] = default(decimal);
-            rulesEngineOptions.DataTypeDefaults[DataTypes.Integer] = default(int);
-            rulesEngineOptions.DataTypeDefaults[DataTypes.String] = string.Empty;
-
-            rulesEngineOptions.DataTypeDefaults[DataTypes.ArrayBoolean] = Enumerable.Empty<bool>();
-            rulesEngineOptions.DataTypeDefaults[DataTypes.ArrayDecimal] = Enumerable.Empty<decimal>();
-            rulesEngineOptions.DataTypeDefaults[DataTypes.ArrayInteger] = Enumerable.Empty<int>();
-            rulesEngineOptions.DataTypeDefaults[DataTypes.ArrayString] = Enumerable.Empty<string>();
 
             return rulesEngineOptions;
         }

--- a/tests/Rules.Framework.Providers.InMemory.IntegrationTests/Scenarios/Scenario5/BestServerTests.cs
+++ b/tests/Rules.Framework.Providers.InMemory.IntegrationTests/Scenarios/Scenario5/BestServerTests.cs
@@ -35,6 +35,16 @@ namespace Rules.Framework.Providers.InMemory.IntegrationTests.Scenarios.Scenario
                     new Condition<BestServerConditions>(BestServerConditions.Brand,"AMD")
                 },
                 "Best Server Default"
+            },
+            new object[]
+            {
+                new[]
+                {
+                    new Condition<BestServerConditions>(BestServerConditions.Price,100),
+                    new Condition<BestServerConditions>(BestServerConditions.Memory,12),
+                    new Condition<BestServerConditions>(BestServerConditions.StoragePartionable,true),
+                },
+                "Best Server Default"
             }
         };
 


### PR DESCRIPTION
## Description

Fixed defaults for array types to the elementary types.

## Change checklist

- [ ] Code follows the [code rules guidelines](../CONTRIBUTING.md#code-rules) of this project
- [ ] Commit messages follow the [commit rules](../CONTRIBUTING.md#commit-rules) of this project
- [x] I have self-reviewed my changes before submitting this pull request
- [ ] I have covered new/changed code with new tests and/or adjusted existent ones
- [ ] I have made changes necessary to update the documentation accordingly

Please also check the [_I want to contribute_](../CONTRIBUTING.md#i-want-to-contribute) guidelines and make sure you have done accordingly.

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)