### PR TITLE
Backwards support for .NET Standard 2.0 (support .NET Framework 4.8)

### DIFF
--- a/src/Rules.Framework/Evaluation/Compiled/RuleConditionsExpressionBuilder.cs
+++ b/src/Rules.Framework/Evaluation/Compiled/RuleConditionsExpressionBuilder.cs
@@ -167,7 +167,11 @@ namespace Rules.Framework.Evaluation.Compiled
 
                 foreach (var multiplicity in operatorMetadata.SupportedMultiplicities)
                 {
+#if NETSTANDARD2_0
+                    string multiplicityTransformed = Regex.Replace(multiplicity, "\\b\\p{Ll}", match => match.Value.ToUpperInvariant(), RegexOptions.None, TimeSpan.FromSeconds(1)).Replace("-", string.Empty);
+#else
                     string multiplicityTransformed = Regex.Replace(multiplicity, "\\b\\p{Ll}", match => match.Value.ToUpperInvariant(), RegexOptions.None, TimeSpan.FromSeconds(1)).Replace("-", string.Empty, StringComparison.Ordinal);
+#endif
                     var scopeName = new StringBuilder(builder.ScopeName)
                         .Append(valueConditionNode.ConditionType)
                         .Append(multiplicityTransformed)

--- a/src/Rules.Framework/Evaluation/OperatorMetadata.cs
+++ b/src/Rules.Framework/Evaluation/OperatorMetadata.cs
@@ -15,7 +15,11 @@ namespace Rules.Framework.Evaluation
             {
                 if (this.leftSupportForOneMultiplicity is null)
                 {
+#if NETSTANDARD2_0
+                    this.leftSupportForOneMultiplicity = this.SupportedMultiplicities?.Any(m => m.Contains("one-to")) ?? false;
+#else
                     this.leftSupportForOneMultiplicity = this.SupportedMultiplicities?.Any(m => m.Contains("one-to", StringComparison.Ordinal)) ?? false;
+#endif
                 }
 
                 return this.leftSupportForOneMultiplicity.GetValueOrDefault();

--- a/src/Rules.Framework/Rules.Framework.csproj
+++ b/src/Rules.Framework/Rules.Framework.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.1</TargetFramework>
+        <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
         <LangVersion>10.0</LangVersion>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <Authors></Authors>
@@ -33,6 +33,15 @@
             <PackagePath></PackagePath>
         </None>
     </ItemGroup>
+
+    <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.32" />
+        <PackageReference Include="Microsoft.Bcl.HashCode" Version="1.1.1" />
+    </ItemGroup>
     
 
     <ItemGroup>
@@ -45,6 +54,5 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
## Description

Add multi-targeting to allow support of Rules.Framework under .NET Framework 4.8 (through .NET Standard 2.0).

## Change checklist

- [x] Code follows the [code rules guidelines](../CONTRIBUTING.md#code-rules) of this project
- [x] Commit messages follow the [commit rules](../CONTRIBUTING.md#commit-rules) of this project
- [x] I have self-reviewed my changes before submitting this pull request
- [x] I have covered new/changed code with new tests and/or adjusted existent ones
- [x] I have made changes necessary to update the documentation accordingly

Please also check the [_I want to contribute_](../CONTRIBUTING.md#i-want-to-contribute) guidelines and make sure you have done accordingly.

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)