### PR TITLE
Support contains operator with many to one multiplicity

### DIFF
--- a/src/Rules.Framework/Evaluation/Compiled/ConditionBuilders/ConditionExpressionBuilderProvider.cs
+++ b/src/Rules.Framework/Evaluation/Compiled/ConditionBuilders/ConditionExpressionBuilderProvider.cs
@@ -12,22 +12,23 @@ namespace Rules.Framework.Evaluation.Compiled.ConditionBuilders
         {
             this.conditionExpressionBuilders = new Dictionary<string, IConditionExpressionBuilder>(StringComparer.Ordinal)
             {
+                { Combine(Operators.CaseInsensitiveEndsWith, Multiplicities.OneToOne), new CaseInsensitiveEndsWithOneToOneConditionExpressionBuilder() },
+                { Combine(Operators.CaseInsensitiveStartsWith, Multiplicities.OneToOne), new CaseInsensitiveStartsWithOneToOneConditionExpressionBuilder() },
+                { Combine(Operators.Contains, Multiplicities.ManyToOne), new ContainsManyToOneConditionExpressionBuilder() },
+                { Combine(Operators.Contains, Multiplicities.OneToOne), new ContainsOneToOneConditionExpressionBuilder() },
+                { Combine(Operators.EndsWith, Multiplicities.OneToOne), new EndsWithOneToOneConditionExpressionBuilder() },
                 { Combine(Operators.Equal, Multiplicities.OneToOne), new EqualOneToOneConditionExpressionBuilder() },
-                { Combine(Operators.NotEqual, Multiplicities.OneToOne), new NotEqualOneToOneConditionExpressionBuilder() },
                 { Combine(Operators.GreaterThan, Multiplicities.OneToOne), new GreaterThanOneToOneConditionExpressionBuilder() },
                 { Combine(Operators.GreaterThanOrEqual, Multiplicities.OneToOne), new GreaterThanOrEqualOneToOneConditionExpressionBuilder() },
+                { Combine(Operators.In, Multiplicities.OneToMany), new InOneToManyConditionExpressionBuilder() },
                 { Combine(Operators.LesserThan, Multiplicities.OneToOne), new LesserThanOneToOneConditionExpressionBuilder() },
                 { Combine(Operators.LesserThanOrEqual, Multiplicities.OneToOne), new LesserThanOrEqualOneToOneConditionExpressionBuilder() },
-                { Combine(Operators.Contains, Multiplicities.OneToOne), new ContainsOneToOneConditionExpressionBuilder() },
                 { Combine(Operators.NotContains, Multiplicities.OneToOne), new NotContainsOneToOneConditionExpressionBuilder() },
-                { Combine(Operators.In, Multiplicities.OneToMany), new InOneToManyConditionExpressionBuilder() },
-                { Combine(Operators.StartsWith, Multiplicities.OneToOne), new StartsWithOneToOneConditionExpressionBuilder() },
-                { Combine(Operators.EndsWith, Multiplicities.OneToOne), new EndsWithOneToOneConditionExpressionBuilder() },
-                { Combine(Operators.CaseInsensitiveStartsWith, Multiplicities.OneToOne), new CaseInsensitiveStartsWithOneToOneConditionExpressionBuilder() },
-                { Combine(Operators.CaseInsensitiveEndsWith, Multiplicities.OneToOne), new CaseInsensitiveEndsWithOneToOneConditionExpressionBuilder() },
                 { Combine(Operators.NotEndsWith, Multiplicities.OneToOne), new NotEndsWithOneToOneConditionExpressionBuilder() },
-                { Combine(Operators.NotStartsWith, Multiplicities.OneToOne), new NotStartsWithOneToOneConditionExpressionBuilder() },
+                { Combine(Operators.NotEqual, Multiplicities.OneToOne), new NotEqualOneToOneConditionExpressionBuilder() },
                 { Combine(Operators.NotIn, Multiplicities.OneToMany), new NotInOneToManyConditionExpressionBuilder() },
+                { Combine(Operators.NotStartsWith, Multiplicities.OneToOne), new NotStartsWithOneToOneConditionExpressionBuilder() },
+                { Combine(Operators.StartsWith, Multiplicities.OneToOne), new StartsWithOneToOneConditionExpressionBuilder() },
             };
         }
 

--- a/src/Rules.Framework/Evaluation/Compiled/ConditionBuilders/ContainsManyToOneConditionExpressionBuilder.cs
+++ b/src/Rules.Framework/Evaluation/Compiled/ConditionBuilders/ContainsManyToOneConditionExpressionBuilder.cs
@@ -1,0 +1,49 @@
+namespace Rules.Framework.Evaluation.Compiled.ConditionBuilders
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Linq.Expressions;
+    using System.Reflection;
+    using Rules.Framework.Core;
+    using Rules.Framework.Evaluation.Compiled.ExpressionBuilders;
+
+    internal sealed class ContainsManyToOneConditionExpressionBuilder : IConditionExpressionBuilder
+    {
+        private static readonly Dictionary<Type, MethodInfo> containsLinqGenericMethodInfos = InitializeLinqContainsMethodInfos();
+        private static readonly DataTypes[] supportedDataTypes = { DataTypes.Boolean, DataTypes.Decimal, DataTypes.Integer, DataTypes.String };
+
+        public Expression BuildConditionExpression(IExpressionBlockBuilder builder, BuildConditionExpressionArgs args)
+        {
+            if (!supportedDataTypes.Contains(args.DataTypeConfiguration.DataType))
+            {
+                throw new NotSupportedException(
+                    $"The operator '{nameof(Operators.Contains)}' is not supported for data type '{args.DataTypeConfiguration.DataType}' on a many to one scenario.");
+            }
+
+            var containsMethodInfo = containsLinqGenericMethodInfos[args.DataTypeConfiguration.Type];
+
+            return builder.AndAlso(
+                builder.NotEqual(args.LeftHandOperand, builder.Constant<object>(value: null!)),
+                builder.Call(
+                    null!,
+                    containsMethodInfo,
+                    new Expression[] { args.LeftHandOperand, args.RightHandOperand }));
+        }
+
+        private static Dictionary<Type, MethodInfo> InitializeLinqContainsMethodInfos()
+        {
+            var genericMethodInfo = typeof(Enumerable)
+                .GetMethods()
+                .First(m => string.Equals(m.Name, nameof(Enumerable.Contains), StringComparison.Ordinal) && m.GetParameters().Length == 2);
+
+            return new Dictionary<Type, MethodInfo>
+            {
+                { typeof(bool), genericMethodInfo.MakeGenericMethod(typeof(bool)) },
+                { typeof(decimal), genericMethodInfo.MakeGenericMethod(typeof(decimal)) },
+                { typeof(int), genericMethodInfo.MakeGenericMethod(typeof(int)) },
+                { typeof(string), genericMethodInfo.MakeGenericMethod(typeof(string)) },
+            };
+        }
+    }
+}

--- a/src/Rules.Framework/Evaluation/Compiled/ConditionBuilders/ContainsOneToOneConditionExpressionBuilder.cs
+++ b/src/Rules.Framework/Evaluation/Compiled/ConditionBuilders/ContainsOneToOneConditionExpressionBuilder.cs
@@ -1,6 +1,7 @@
 namespace Rules.Framework.Evaluation.Compiled.ConditionBuilders
 {
     using System;
+    using System.Linq;
     using System.Linq.Expressions;
     using System.Reflection;
     using Rules.Framework.Core;
@@ -8,17 +9,18 @@ namespace Rules.Framework.Evaluation.Compiled.ConditionBuilders
 
     internal sealed class ContainsOneToOneConditionExpressionBuilder : IConditionExpressionBuilder
     {
-        private static readonly MethodInfo stringContainsMethodInfo = typeof(string).GetMethod("Contains", new[] { typeof(string) });
+        private static readonly MethodInfo stringContainsMethodInfo = typeof(string).GetMethod(nameof(Enumerable.Contains), new[] { typeof(string) });
 
         public Expression BuildConditionExpression(IExpressionBlockBuilder builder, BuildConditionExpressionArgs args)
         {
             if (args.DataTypeConfiguration.DataType != DataTypes.String)
             {
-                throw new NotSupportedException($"The operator '{Operators.Contains}' is not supported for data type '{args.DataTypeConfiguration.DataType}'.");
+                throw new NotSupportedException(
+                    $"The operator '{nameof(Operators.Contains)}' is not supported for data type '{args.DataTypeConfiguration.DataType}' on a one to one scenario.");
             }
 
             return builder.AndAlso(
-                builder.NotEqual(args.LeftHandOperand, builder.Constant<object>(value: null)),
+                builder.NotEqual(args.LeftHandOperand, builder.Constant<object>(value: null!)),
                 builder.Call(
                     args.LeftHandOperand,
                     stringContainsMethodInfo,

--- a/src/Rules.Framework/Evaluation/Interpreted/ValueEvaluation/ContainsOperatorEvalStrategy.cs
+++ b/src/Rules.Framework/Evaluation/Interpreted/ValueEvaluation/ContainsOperatorEvalStrategy.cs
@@ -1,20 +1,29 @@
 namespace Rules.Framework.Evaluation.Interpreted.ValueEvaluation
 {
     using System;
+    using System.Collections.Generic;
+    using System.Linq;
 
-    internal sealed class ContainsOperatorEvalStrategy : IOneToOneOperatorEvalStrategy
+    internal sealed class ContainsOperatorEvalStrategy : IOneToOneOperatorEvalStrategy, IManyToOneOperatorEvalStrategy
     {
         public bool Eval(object leftOperand, object rightOperand)
         {
             if (leftOperand is string)
             {
-                string leftOperandAsString = leftOperand as string;
-                string rightOperandAsString = rightOperand as string;
+                var leftOperandAsString = leftOperand as string;
+                var rightOperandAsString = rightOperand as string;
 
-                return leftOperandAsString.Contains(rightOperandAsString);
+#if NETSTANDARD2_1_OR_GREATER
+                return leftOperandAsString!.Contains(rightOperandAsString, StringComparison.Ordinal);
+#else
+                return leftOperandAsString!.Contains(rightOperandAsString);
+#endif
             }
 
             throw new NotSupportedException($"Unsupported 'contains' comparison between operands of type '{leftOperand?.GetType().FullName}'.");
         }
+
+        public bool Eval(IEnumerable<object> leftOperand, object rightOperand)
+            => leftOperand.Contains(rightOperand);
     }
 }

--- a/src/Rules.Framework/Evaluation/OperatorsMetadata.cs
+++ b/src/Rules.Framework/Evaluation/OperatorsMetadata.cs
@@ -76,7 +76,7 @@ namespace Rules.Framework.Evaluation
         public static OperatorMetadata Contains => new()
         {
             Operator = Operators.Contains,
-            SupportedMultiplicities = new[] { Multiplicities.OneToOne },
+            SupportedMultiplicities = new[] { Multiplicities.OneToOne, Multiplicities.ManyToOne },
         };
 
         public static OperatorMetadata EndsWith => new()

--- a/tests/Rules.Framework.IntegrationTests/Rules.Framework.IntegrationTests.csproj
+++ b/tests/Rules.Framework.IntegrationTests/Rules.Framework.IntegrationTests.csproj
@@ -23,7 +23,7 @@
 		<PackageReference Include="FluentAssertions" Version="6.10.0" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-		<PackageReference Include="xunit" Version="2.4.2" />
+		<PackageReference Include="xunit" Version="2.7.1" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Rules.Framework.Providers.InMemory.IntegrationTests/Features/RulesEngine/RulesEngineTestsBase.cs
+++ b/tests/Rules.Framework.Providers.InMemory.IntegrationTests/Features/RulesEngine/RulesEngineTestsBase.cs
@@ -2,6 +2,7 @@ namespace Rules.Framework.Providers.InMemory.IntegrationTests.Features.RulesEngi
 {
     using System;
     using System.Collections.Generic;
+    using System.Globalization;
     using System.Threading.Tasks;
     using Rules.Framework.Core;
     using Rules.Framework.IntegrationTests.Common.Features;
@@ -15,7 +16,19 @@ namespace Rules.Framework.Providers.InMemory.IntegrationTests.Features.RulesEngi
         {
             this.TestContentType = testContentType;
 
-            this.RulesEngine = RulesEngineBuilder
+            this.CompiledRulesEngine = RulesEngineBuilder
+                .CreateRulesEngine()
+                .WithContentType<ContentType>()
+                .WithConditionType<ConditionType>()
+                .SetInMemoryDataSource()
+                .Configure(c =>
+                {
+                    c.EnableCompilation = true;
+                    c.PriorityCriteria = PriorityCriterias.TopmostRuleWins;
+                })
+                .Build();
+
+            this.InterpretedRulesEngine = RulesEngineBuilder
                 .CreateRulesEngine()
                 .WithContentType<ContentType>()
                 .WithConditionType<ConditionType>()
@@ -24,27 +37,76 @@ namespace Rules.Framework.Providers.InMemory.IntegrationTests.Features.RulesEngi
                 .Build();
         }
 
-        protected RulesEngine<ContentType, ConditionType> RulesEngine { get; }
+        protected RulesEngine<ContentType, ConditionType> CompiledRulesEngine { get; }
+
+        protected RulesEngine<ContentType, ConditionType> InterpretedRulesEngine { get; }
+
+        protected async Task<RuleOperationResult> ActivateRuleAsync(Rule<ContentType, ConditionType> rule, bool compiled)
+        {
+            if (compiled)
+            {
+                return await CompiledRulesEngine.ActivateRuleAsync(rule);
+            }
+            else
+            {
+                return await InterpretedRulesEngine.ActivateRuleAsync(rule);
+            }
+        }
 
         protected void AddRules(IEnumerable<RuleSpecification> ruleSpecifications)
         {
             foreach (var ruleSpecification in ruleSpecifications)
             {
-                this.RulesEngine.AddRuleAsync(
-                    ruleSpecification.Rule,
-                    ruleSpecification.RuleAddPriorityOption)
-                    .ConfigureAwait(false)
+                this.CompiledRulesEngine.AddRuleAsync(ruleSpecification.Rule, ruleSpecification.RuleAddPriorityOption)
+                    .GetAwaiter()
+                    .GetResult();
+
+                this.InterpretedRulesEngine.AddRuleAsync(ruleSpecification.Rule, ruleSpecification.RuleAddPriorityOption)
                     .GetAwaiter()
                     .GetResult();
             }
         }
 
+        protected async Task<RuleOperationResult> DeactivateRuleAsync(Rule<ContentType, ConditionType> rule, bool compiled)
+        {
+            if (compiled)
+            {
+                return await CompiledRulesEngine.DeactivateRuleAsync(rule);
+            }
+            else
+            {
+                return await InterpretedRulesEngine.DeactivateRuleAsync(rule);
+            }
+        }
+
         protected async Task<Rule<ContentType, ConditionType>> MatchOneAsync(
             DateTime matchDate,
-            Condition<ConditionType>[] conditions) => await RulesEngine.MatchOneAsync(
-                TestContentType,
-                matchDate,
-                conditions)
-            .ConfigureAwait(false);
+            Condition<ConditionType>[] conditions,
+            bool compiled)
+        {
+            if (compiled)
+            {
+                return await CompiledRulesEngine.MatchOneAsync(TestContentType, matchDate, conditions);
+            }
+            else
+            {
+                return await InterpretedRulesEngine.MatchOneAsync(TestContentType, matchDate, conditions);
+            }
+        }
+
+        protected async Task<RuleOperationResult> UpdateRuleAsync(Rule<ContentType, ConditionType> rule, bool compiled)
+        {
+            if (compiled)
+            {
+                return await CompiledRulesEngine.UpdateRuleAsync(rule);
+            }
+            else
+            {
+                return await InterpretedRulesEngine.UpdateRuleAsync(rule);
+            }
+        }
+
+        protected DateTime UtcDate(string date)
+            => DateTime.Parse(date, CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal);
     }
 }

--- a/tests/Rules.Framework.Providers.InMemory.IntegrationTests/Features/RulesEngine/RulesMatching/OperatorContainsManyToOneTests.cs
+++ b/tests/Rules.Framework.Providers.InMemory.IntegrationTests/Features/RulesEngine/RulesMatching/OperatorContainsManyToOneTests.cs
@@ -41,9 +41,9 @@ namespace Rules.Framework.Providers.InMemory.IntegrationTests.Features.RulesEngi
         public async Task RulesEngine_GivenConditionType1WithArrayOfStringsContainingCat_MatchesExpectedRule(bool compiled)
         {
             // Arrange
-            var emptyConditions = new Condition<ConditionType>[]
+            var emptyConditions = new[]
             {
-                new(ConditionType.ConditionType1, new[]{ "Dog", "Fish", "Cat", "Spider", "Mockingbird", })
+                new Condition<ConditionType>(ConditionType.ConditionType1, new[]{ "Dog", "Fish", "Cat", "Spider", "Mockingbird", })
             };
             var matchDate = UtcDate("2020-01-02Z");
 

--- a/tests/Rules.Framework.Providers.InMemory.IntegrationTests/Features/RulesEngine/RulesMatching/OperatorContainsManyToOneTests.cs
+++ b/tests/Rules.Framework.Providers.InMemory.IntegrationTests/Features/RulesEngine/RulesMatching/OperatorContainsManyToOneTests.cs
@@ -1,0 +1,87 @@
+namespace Rules.Framework.Providers.InMemory.IntegrationTests.Features.RulesEngine.RulesMatching
+{
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using FluentAssertions;
+    using Rules.Framework.Core;
+    using Rules.Framework.IntegrationTests.Common.Features;
+    using Rules.Framework.Tests.Stubs;
+    using Xunit;
+
+    public class OperatorContainsManyToOneTests : RulesEngineTestsBase
+    {
+        private static readonly ContentType testContentType = ContentType.ContentType1;
+        private readonly Rule<ContentType, ConditionType> expectedMatchRule;
+        private readonly Rule<ContentType, ConditionType> otherRule;
+
+        public OperatorContainsManyToOneTests()
+            : base(testContentType)
+        {
+            this.expectedMatchRule = RuleBuilder.NewRule<ContentType, ConditionType>()
+                .WithName("Expected rule")
+                .WithDateBegin(UtcDate("2020-01-01Z"))
+                .WithContent(testContentType, "Just as expected!")
+                .WithCondition(ConditionType.ConditionType1, Operators.Contains, "Cat")
+                .Build()
+                .Rule;
+
+            this.otherRule = RuleBuilder.NewRule<ContentType, ConditionType>()
+                .WithName("Other rule")
+                .WithDateBegin(UtcDate("2020-01-01Z"))
+                .WithContent(testContentType, "Oops! Not expected to be matched.")
+                .Build()
+                .Rule;
+
+            this.AddRules(this.CreateTestRules());
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task RulesEngine_GivenConditionType1WithArrayOfStringsContainingCat_MatchesExpectedRule(bool compiled)
+        {
+            // Arrange
+            var emptyConditions = new Condition<ConditionType>[]
+            {
+                new(ConditionType.ConditionType1, new[]{ "Dog", "Fish", "Cat", "Spider", "Mockingbird", })
+            };
+            var matchDate = UtcDate("2020-01-02Z");
+
+            // Act
+            var actualMatch = await this.MatchOneAsync(matchDate, emptyConditions, compiled);
+
+            // Assert
+            actualMatch.Should().BeEquivalentTo(expectedMatchRule);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task RulesEngine_GivenConditionType1WithArrayOfStringsNotContainingCat_MatchesOtherRule(bool compiled)
+        {
+            // Arrange
+            var emptyConditions = new Condition<ConditionType>[]
+            {
+                new(ConditionType.ConditionType1, new[]{ "Dog", "Fish", "Bat", "Spider", "Mockingbird", })
+            };
+            var matchDate = UtcDate("2020-01-02Z");
+
+            // Act
+            var actualMatch = await this.MatchOneAsync(matchDate, emptyConditions, compiled);
+
+            // Assert
+            actualMatch.Should().BeEquivalentTo(otherRule);
+        }
+
+        private IEnumerable<RuleSpecification> CreateTestRules()
+        {
+            var ruleSpecs = new List<RuleSpecification>
+            {
+                new RuleSpecification(expectedMatchRule, RuleAddPriorityOption.ByPriorityNumber(1)),
+                new RuleSpecification(otherRule, RuleAddPriorityOption.ByPriorityNumber(2))
+            };
+
+            return ruleSpecs;
+        }
+    }
+}

--- a/tests/Rules.Framework.Providers.InMemory.IntegrationTests/Features/RulesEngine/RulesMatching/OperatorContainsManyToOneTests.cs
+++ b/tests/Rules.Framework.Providers.InMemory.IntegrationTests/Features/RulesEngine/RulesMatching/OperatorContainsManyToOneTests.cs
@@ -60,9 +60,9 @@ namespace Rules.Framework.Providers.InMemory.IntegrationTests.Features.RulesEngi
         public async Task RulesEngine_GivenConditionType1WithArrayOfStringsNotContainingCat_MatchesOtherRule(bool compiled)
         {
             // Arrange
-            var emptyConditions = new Condition<ConditionType>[]
+            var emptyConditions = new[]
             {
-                new(ConditionType.ConditionType1, new[]{ "Dog", "Fish", "Bat", "Spider", "Mockingbird", })
+                new Condition<ConditionType>(ConditionType.ConditionType1, new[]{ "Dog", "Fish", "Bat", "Spider", "Mockingbird", })
             };
             var matchDate = UtcDate("2020-01-02Z");
 

--- a/tests/Rules.Framework.Providers.InMemory.IntegrationTests/Features/RulesEngine/RulesMatching/RulesDeactivateAndActivateTests.cs
+++ b/tests/Rules.Framework.Providers.InMemory.IntegrationTests/Features/RulesEngine/RulesMatching/RulesDeactivateAndActivateTests.cs
@@ -3,7 +3,6 @@ namespace Rules.Framework.Providers.InMemory.IntegrationTests.Features.RulesEngi
     using System;
     using System.Collections.Generic;
     using System.Threading.Tasks;
-    using Rules.Framework.Builder;
     using Rules.Framework.Core;
     using Rules.Framework.IntegrationTests.Common.Features;
     using Rules.Framework.Providers.InMemory.IntegrationTests.Features.RulesEngine;
@@ -42,28 +41,30 @@ namespace Rules.Framework.Providers.InMemory.IntegrationTests.Features.RulesEngi
             this.AddRules(this.CreateTestRules());
         }
 
-        [Fact]
-        public async Task RulesEngine_DeactivateThenActivateRule_Validations()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task RulesEngine_DeactivateThenActivateRule_Validations(bool compiled)
         {
             // Arrange
             var emptyConditions = Array.Empty<Condition<ConditionType>>();
             var matchDate = new DateTime(2020, 01, 02);
 
             // Act 1: Deactivate the rule
-            var deactivateResult = await this.RulesEngine.DeactivateRuleAsync(rule1);
+            var deactivateResult = await this.DeactivateRuleAsync(rule1, compiled);
 
             // Assert 1: Rule 2 must be found
             Assert.True(deactivateResult.IsSuccess);
-            var actualMatch1 = await this.MatchOneAsync(matchDate, emptyConditions).ConfigureAwait(false);
+            var actualMatch1 = await this.MatchOneAsync(matchDate, emptyConditions, compiled);
             Assert.NotNull(actualMatch1);
             Assert.Equal(rule2.Name, actualMatch1.Name);
 
             // Act 2: Activate the rule
-            var activateResult = await this.RulesEngine.ActivateRuleAsync(rule1);
+            var activateResult = await this.ActivateRuleAsync(rule1, compiled);
 
             // Assert 2: Rule 1 must be found
             Assert.True(activateResult.IsSuccess);
-            var actualMatch2 = await this.MatchOneAsync(matchDate, emptyConditions).ConfigureAwait(false);
+            var actualMatch2 = await this.MatchOneAsync(matchDate, emptyConditions, compiled);
             Assert.NotNull(actualMatch2);
             Assert.Equal(rule1.Name, actualMatch2.Name);
         }

--- a/tests/Rules.Framework.Providers.InMemory.IntegrationTests/Features/RulesEngine/RulesMatching/RulesUpdateDateEndTests.cs
+++ b/tests/Rules.Framework.Providers.InMemory.IntegrationTests/Features/RulesEngine/RulesMatching/RulesUpdateDateEndTests.cs
@@ -3,7 +3,6 @@ namespace Rules.Framework.Providers.InMemory.IntegrationTests.Features.RulesEngi
     using System;
     using System.Collections.Generic;
     using System.Threading.Tasks;
-    using Rules.Framework.Builder;
     using Rules.Framework.Core;
     using Rules.Framework.IntegrationTests.Common.Features;
     using Rules.Framework.Providers.InMemory.IntegrationTests.Features.RulesEngine;
@@ -45,13 +44,15 @@ namespace Rules.Framework.Providers.InMemory.IntegrationTests.Features.RulesEngi
         public static IEnumerable<object[]> Cases =>
             new List<object[]>
             {
-                new object[] { new DateTime(2020, 01, 01), true },
-                new object[] { new DateTime(2020, 01, 01).AddMilliseconds(-1), false },
+                new object[] { new DateTime(2020, 01, 01), true, false },
+                new object[] { new DateTime(2020, 01, 01), true, true },
+                new object[] { new DateTime(2020, 01, 01).AddMilliseconds(-1), false, false },
+                new object[] { new DateTime(2020, 01, 01).AddMilliseconds(-1), false, true },
             };
 
         [Theory]
         [MemberData(nameof(Cases))]
-        public async Task RulesEngine_UpdateRuleDateEnd_Validations(DateTime dateEnd, bool success)
+        public async Task RulesEngine_UpdateRuleDateEnd_Validations(DateTime dateEnd, bool success, bool compiled)
         {
             // Arrange
             var emptyConditions = Array.Empty<Condition<ConditionType>>();
@@ -59,13 +60,13 @@ namespace Rules.Framework.Providers.InMemory.IntegrationTests.Features.RulesEngi
 
             // Act
             rule1.DateEnd = dateEnd;
-            var updateResult = await this.RulesEngine.UpdateRuleAsync(rule1);
+            var updateResult = await this.UpdateRuleAsync(rule1, compiled);
 
             // Assert
             Assert.Equal(success, updateResult.IsSuccess);
             if (success)
             {
-                var actualMatch = await this.MatchOneAsync(matchDate, emptyConditions).ConfigureAwait(false);
+                var actualMatch = await this.MatchOneAsync(matchDate, emptyConditions, compiled);
                 Assert.NotNull(actualMatch);
                 Assert.Equal(rule2.Name, actualMatch.Name);
             }

--- a/tests/Rules.Framework.Providers.InMemory.IntegrationTests/Rules.Framework.Providers.InMemory.IntegrationTests.csproj
+++ b/tests/Rules.Framework.Providers.InMemory.IntegrationTests/Rules.Framework.Providers.InMemory.IntegrationTests.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="FluentAssertions" Version="6.10.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit" Version="2.7.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/tests/Rules.Framework.Providers.MongoDb.IntegrationTests/Rules.Framework.Providers.MongoDb.IntegrationTests.csproj
+++ b/tests/Rules.Framework.Providers.MongoDb.IntegrationTests/Rules.Framework.Providers.MongoDb.IntegrationTests.csproj
@@ -30,7 +30,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="MongoDB.Driver" Version="2.19.0" />
     <PackageReference Include="Newtonsoft.Json.Bson" Version="1.0.2" />
-    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit" Version="2.7.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Rules.Framework.Providers.MongoDb.Tests/Rules.Framework.Providers.MongoDb.Tests.csproj
+++ b/tests/Rules.Framework.Providers.MongoDb.Tests/Rules.Framework.Providers.MongoDb.Tests.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="MongoDB.Driver" Version="2.19.0" />
     <PackageReference Include="Moq" Version="4.18.4" />
-    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit" Version="2.7.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Rules.Framework.Tests/Evaluation/Compiled/ConditionBuilders/ContainsManyToOneConditionExpressionBuilderTests.cs
+++ b/tests/Rules.Framework.Tests/Evaluation/Compiled/ConditionBuilders/ContainsManyToOneConditionExpressionBuilderTests.cs
@@ -1,0 +1,115 @@
+namespace Rules.Framework.Tests.Evaluation.Compiled.ConditionBuilders
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq.Expressions;
+    using FluentAssertions;
+    using Moq;
+    using Rules.Framework.Core;
+    using Rules.Framework.Evaluation;
+    using Rules.Framework.Evaluation.Compiled.ConditionBuilders;
+    using Rules.Framework.Evaluation.Compiled.ExpressionBuilders;
+    using Xunit;
+
+    public class ContainsManyToOneConditionExpressionBuilderTests
+    {
+        private readonly ContainsManyToOneConditionExpressionBuilder conditionExpressionBuilder;
+
+        public ContainsManyToOneConditionExpressionBuilderTests()
+        {
+            this.conditionExpressionBuilder = new ContainsManyToOneConditionExpressionBuilder();
+        }
+
+        public static IEnumerable<object[]> NotSupportedExceptionCases => new[]
+        {
+            new object[] { DataTypes.ArrayBoolean, typeof(IEnumerable<bool>), new[] { true, false } },
+            new object[] { DataTypes.ArrayDecimal, typeof(IEnumerable<decimal>), new[] { 1.1m, 2.6m } },
+            new object[] { DataTypes.ArrayInteger, typeof(IEnumerable<int>), new[] { 1, 2 } },
+            new object[] { DataTypes.ArrayString, typeof(IEnumerable<string>), new[] { "A", "B" } },
+        };
+
+        public static IEnumerable<object[]> ValidCases => new[]
+        {
+            new object[]{ DataTypes.Boolean, typeof(IEnumerable<bool>), typeof(bool), new[] { true, }, new[] { false, }, true },
+            new object[]{ DataTypes.Decimal, typeof(IEnumerable<decimal>), typeof(decimal), new[] { 10.5m, 3.6m, 1.9m, }, new[] { 2.4m, 5.6m, 7.0m, }, 10.5m },
+            new object[]{ DataTypes.Integer, typeof(IEnumerable<int>), typeof(int), new[] { 1, 2, 3, 4, 5, }, new[] { 10, 11, 12, 13, 14, }, 3 },
+            new object[]{ DataTypes.String, typeof(IEnumerable<string>), typeof(string), new[] { "A", "B", "C", "D", }, new[] { "E", "F", "G", "H", }, "C" },
+        };
+
+        [Theory]
+        [MemberData(nameof(NotSupportedExceptionCases))]
+        public void BuildConditionExpression_GivenLeftExpressionRightExpressionAndDataTypeConfigurationForInt_ReturnsConditionExpression(
+            DataTypes dataType,
+            Type type,
+            object leftOperand)
+        {
+            // Arrange
+            var args = new BuildConditionExpressionArgs
+            {
+                DataTypeConfiguration = DataTypeConfiguration.Create(dataType, type, null),
+                LeftHandOperand = Expression.Constant(leftOperand),
+                RightHandOperand = Expression.Constant(2),
+            };
+
+            var builder = Mock.Of<IExpressionBlockBuilder>();
+
+            // Act
+            var notSupportedException = Assert.Throws<NotSupportedException>(() => this.conditionExpressionBuilder
+                .BuildConditionExpression(builder, args));
+
+            // Assert
+            notSupportedException.Should().NotBeNull();
+            notSupportedException.Message
+                .Should()
+                .Contain(Operators.Contains.ToString())
+                .And
+                .Contain(dataType.ToString());
+        }
+
+        [Theory]
+        [MemberData(nameof(ValidCases))]
+        public void BuildConditionExpression_GivenLeftExpressionRightExpressionAndDataTypeConfigurationForString_ReturnsConditionExpression(
+            DataTypes dataType,
+            Type leftOperandType,
+            Type rightOperandType,
+            object leftOperandMatch,
+            object leftOperandNonMatch,
+            object rightOperand)
+        {
+            // Act
+            var expressionResult = ExpressionBuilder.NewExpression("TestCondition")
+                .WithParameters(p =>
+                {
+                    p.CreateParameter("leftHand", typeof(object));
+                })
+                .HavingReturn(typeof(bool), false)
+                .SetImplementation(builder =>
+                {
+                    var args = new BuildConditionExpressionArgs
+                    {
+                        DataTypeConfiguration = DataTypeConfiguration.Create(dataType, rightOperandType, null),
+                        LeftHandOperand = builder.ConvertChecked(builder.GetParameter("leftHand"), leftOperandType),
+                        RightHandOperand = builder.ConvertChecked(builder.Constant(rightOperand), rightOperandType),
+                    };
+                    var conditionExpression = this.conditionExpressionBuilder
+                        .BuildConditionExpression(builder, args);
+
+                    builder.Return(conditionExpression);
+                })
+                .Build();
+
+            // Assert
+            var actualExpression = expressionResult.Implementation;
+            actualExpression.Should().NotBeNull();
+
+            var compiledExpression = Expression.Lambda<Func<object, bool>>(actualExpression, expressionResult.Parameters).Compile(true);
+            var notNullLeftHandValueResult1 = compiledExpression.Invoke(leftOperandMatch);
+            var notNullLeftHandValueResult2 = compiledExpression.Invoke(leftOperandNonMatch);
+            var nullLeftHandValueResult = compiledExpression.Invoke(null);
+
+            notNullLeftHandValueResult1.Should().BeTrue();
+            notNullLeftHandValueResult2.Should().BeFalse();
+            nullLeftHandValueResult.Should().BeFalse();
+        }
+    }
+}

--- a/tests/Rules.Framework.Tests/Evaluation/Compiled/ConditionBuilders/ContainsOneToOneConditionExpressionBuilderTests.cs
+++ b/tests/Rules.Framework.Tests/Evaluation/Compiled/ConditionBuilders/ContainsOneToOneConditionExpressionBuilderTests.cs
@@ -12,6 +12,13 @@ namespace Rules.Framework.Tests.Evaluation.Compiled.ConditionBuilders
 
     public class ContainsOneToOneConditionExpressionBuilderTests
     {
+        private readonly ContainsOneToOneConditionExpressionBuilder containsOneToOneConditionExpressionBuilder;
+
+        public ContainsOneToOneConditionExpressionBuilderTests()
+        {
+            this.containsOneToOneConditionExpressionBuilder = new ContainsOneToOneConditionExpressionBuilder();
+        }
+
         [Fact]
         public void BuildConditionExpression_GivenLeftExpressionRightExpressionAndDataTypeConfigurationForInt_ReturnsConditionExpression()
         {
@@ -25,11 +32,8 @@ namespace Rules.Framework.Tests.Evaluation.Compiled.ConditionBuilders
 
             var builder = Mock.Of<IExpressionBlockBuilder>();
 
-            var containsOneToOneConditionExpressionBuilder
-                = new ContainsOneToOneConditionExpressionBuilder();
-
             // Act
-            var notSupportedException = Assert.Throws<NotSupportedException>(() => containsOneToOneConditionExpressionBuilder
+            var notSupportedException = Assert.Throws<NotSupportedException>(() => this.containsOneToOneConditionExpressionBuilder
                 .BuildConditionExpression(builder, args));
 
             // Assert
@@ -44,10 +48,6 @@ namespace Rules.Framework.Tests.Evaluation.Compiled.ConditionBuilders
         [Fact]
         public void BuildConditionExpression_GivenLeftExpressionRightExpressionAndDataTypeConfigurationForString_ReturnsConditionExpression()
         {
-            // Arrange
-            var containsOneToOneConditionExpressionBuilder
-                = new ContainsOneToOneConditionExpressionBuilder();
-
             // Act
             var expressionResult = ExpressionBuilder.NewExpression("TestCondition")
                 .WithParameters(p =>
@@ -63,7 +63,7 @@ namespace Rules.Framework.Tests.Evaluation.Compiled.ConditionBuilders
                         LeftHandOperand = builder.GetParameter("leftHand"),
                         RightHandOperand = builder.Constant("quick"),
                     };
-                    var conditionExpression = containsOneToOneConditionExpressionBuilder
+                    var conditionExpression = this.containsOneToOneConditionExpressionBuilder
                         .BuildConditionExpression(builder, args);
 
                     builder.Return(conditionExpression);

--- a/tests/Rules.Framework.Tests/Evaluation/Interpreted/ValueEvaluation/ContainsOperatorEvalStrategyTests.cs
+++ b/tests/Rules.Framework.Tests/Evaluation/Interpreted/ValueEvaluation/ContainsOperatorEvalStrategyTests.cs
@@ -1,23 +1,69 @@
 namespace Rules.Framework.Tests.Evaluation.Interpreted.ValueEvaluation
 {
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Linq;
     using FluentAssertions;
     using Rules.Framework.Evaluation.Interpreted.ValueEvaluation;
-    using System;
     using Xunit;
 
     public class ContainsOperatorEvalStrategyTests
     {
+        private readonly ContainsOperatorEvalStrategy operatorEvalStrategy;
+
+        public ContainsOperatorEvalStrategyTests()
+        {
+            this.operatorEvalStrategy = new ContainsOperatorEvalStrategy();
+        }
+
+        public static IEnumerable<object[]> ArrayLeftOperandFailureCases => new[]
+        {
+            new object[] { new[] { true, }, false },
+            new object[] { new[] { 6.5m, 7.1m, 8.6m, }, 8.1m },
+            new object[] { new[] { 1, 2, 3, 4, 5, }, 10 },
+            new object[] { new[] { "C", "F", "M", "Z", }, "A" },
+        };
+
+        public static IEnumerable<object[]> ArrayLeftOperandSuccessCases => new[]
+        {
+            new object[] { new[] { true, }, true },
+            new object[] { new[] { 6.5m, 7.1m, 8.6m, }, 6.5m },
+            new object[] { new[] { 1, 2, 3, 4, 5, }, 4 },
+            new object[] { new[] { "C", "F", "M", "Z", }, "M" },
+        };
+
+        [Theory]
+        [MemberData(nameof(ArrayLeftOperandFailureCases))]
+        public void Eval_GivenArrayOfTypeAndType_ReturnsFalse(IEnumerable expectedLeftOperand, object expectedRightOperand)
+        {
+            // Act
+            var actual = this.operatorEvalStrategy.Eval(expectedLeftOperand.Cast<object>(), expectedRightOperand);
+
+            // Arrange
+            actual.Should().BeFalse();
+        }
+
+        [Theory]
+        [MemberData(nameof(ArrayLeftOperandSuccessCases))]
+        public void Eval_GivenArrayOfTypeAndType_ReturnsTrue(IEnumerable expectedLeftOperand, object expectedRightOperand)
+        {
+            // Act
+            var actual = this.operatorEvalStrategy.Eval(expectedLeftOperand.Cast<object>(), expectedRightOperand);
+
+            // Arrange
+            actual.Should().BeTrue();
+        }
+
         [Fact]
         public void Eval_GivenIntegers1And2_ThrowsNotSupportedException()
         {
             // Arrange
-            int expectedLeftOperand = 1;
-            int expectedRightOperand = 2;
-
-            ContainsOperatorEvalStrategy sut = new ContainsOperatorEvalStrategy();
+            var expectedLeftOperand = 1;
+            var expectedRightOperand = 2;
 
             // Act
-            NotSupportedException notSupportedException = Assert.Throws<NotSupportedException>(() => sut.Eval(expectedLeftOperand, expectedRightOperand));
+            var notSupportedException = Assert.Throws<NotSupportedException>(() => this.operatorEvalStrategy.Eval(expectedLeftOperand, expectedRightOperand));
 
             // Arrange
             notSupportedException.Should().NotBeNull();
@@ -28,13 +74,11 @@ namespace Rules.Framework.Tests.Evaluation.Interpreted.ValueEvaluation
         public void Eval_GivenStringsTheQuickBrownFoxJumpsOverTheLazyDogAndFox_ReturnsTrue()
         {
             // Arrange
-            string expectedLeftOperand = "The quick brown fox jumps over the lazy dog";
-            string expectedRightOperand = "fox";
-
-            ContainsOperatorEvalStrategy sut = new ContainsOperatorEvalStrategy();
+            var expectedLeftOperand = "The quick brown fox jumps over the lazy dog";
+            var expectedRightOperand = "fox";
 
             // Act
-            bool actual = sut.Eval(expectedLeftOperand, expectedRightOperand);
+            var actual = this.operatorEvalStrategy.Eval(expectedLeftOperand, expectedRightOperand);
 
             // Arrange
             actual.Should().BeTrue();
@@ -44,13 +88,11 @@ namespace Rules.Framework.Tests.Evaluation.Interpreted.ValueEvaluation
         public void Eval_GivenStringsTheQuickBrownFoxJumpsOverTheLazyDogAndYellow_ReturnsFalse()
         {
             // Arrange
-            string expectedLeftOperand = "The quick brown fox jumps over the lazy dog";
-            string expectedRightOperand = "yellow";
-
-            ContainsOperatorEvalStrategy sut = new ContainsOperatorEvalStrategy();
+            var expectedLeftOperand = "The quick brown fox jumps over the lazy dog";
+            var expectedRightOperand = "yellow";
 
             // Act
-            bool actual = sut.Eval(expectedLeftOperand, expectedRightOperand);
+            var actual = this.operatorEvalStrategy.Eval(expectedLeftOperand, expectedRightOperand);
 
             // Arrange
             actual.Should().BeFalse();

--- a/tests/Rules.Framework.Tests/Rules.Framework.Tests.csproj
+++ b/tests/Rules.Framework.Tests/Rules.Framework.Tests.csproj
@@ -45,7 +45,7 @@
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
 		<PackageReference Include="Moq" Version="4.18.4" />
-		<PackageReference Include="xunit" Version="2.4.2" />
+		<PackageReference Include="xunit" Version="2.7.1" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Rules.Framework.WebUI.Tests/Rules.Framework.WebUI.Tests.csproj
+++ b/tests/Rules.Framework.WebUI.Tests/Rules.Framework.WebUI.Tests.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="Moq" Version="4.18.4" />
-    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit" Version="2.7.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
## Description

Adds support for the contains operator under a many to one multiplicity, allowing supplying as parameter collections of strings, integers, booleans, and decimals.

Closes #164.

## Change checklist

- [x] Code follows the [code rules guidelines](../CONTRIBUTING.md#code-rules) of this project
- [x] Commit messages follow the [commit rules](../CONTRIBUTING.md#commit-rules) of this project
- [x] I have self-reviewed my changes before submitting this pull request
- [x] I have covered new/changed code with new tests and/or adjusted existent ones
- [ ] I have made changes necessary to update the documentation accordingly

Please also check the [_I want to contribute_](../CONTRIBUTING.md#i-want-to-contribute) guidelines and make sure you have done accordingly.

## Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)